### PR TITLE
Measure $package suite

### DIFF
--- a/lib/measure_repository_service_test_kit.rb
+++ b/lib/measure_repository_service_test_kit.rb
@@ -44,7 +44,6 @@ module MeasureRepositoryServiceTestKit
 
         run do
           fhir_get_capability_statement
-
           assert_response_status(200)
           assert_resource_type(:capability_statement)
         end

--- a/lib/measure_repository_service_test_kit.rb
+++ b/lib/measure_repository_service_test_kit.rb
@@ -2,6 +2,8 @@
 
 require_relative 'measure_repository_service_test_kit/measure_group'
 require_relative 'measure_repository_service_test_kit/library_group'
+require_relative 'measure_repository_service_test_kit/measure_package'
+
 module MeasureRepositoryServiceTestKit
   # Overall test suite
   class Suite < Inferno::TestSuite
@@ -52,5 +54,6 @@ module MeasureRepositoryServiceTestKit
     # Tests and TestGroups from separate files (included using their id)
     group from: :measure_group
     group from: :library_group
+    group from: :measure_package
   end
 end

--- a/lib/measure_repository_service_test_kit/library_group.rb
+++ b/lib/measure_repository_service_test_kit/library_group.rb
@@ -5,7 +5,7 @@ require 'json'
 module MeasureRepositoryServiceTestKit
   # tests for read by ID and search for Library service
   class LibraryGroup < Inferno::TestGroup
-    title 'Measure Repository Service Library Group'
+    title 'Library Group'
     description 'Ensure measure repository service can retrieve Library resources by the server-defined id and search'
     id 'library_group'
 

--- a/lib/measure_repository_service_test_kit/library_group.rb
+++ b/lib/measure_repository_service_test_kit/library_group.rb
@@ -5,7 +5,7 @@ require 'json'
 module MeasureRepositoryServiceTestKit
   # tests for read by ID and search for Library service
   class LibraryGroup < Inferno::TestGroup
-    title 'Library Group'
+    title 'Library Read by Id and Search'
     description 'Ensure measure repository service can retrieve Library resources by the server-defined id and search'
     id 'library_group'
 

--- a/lib/measure_repository_service_test_kit/measure_group.rb
+++ b/lib/measure_repository_service_test_kit/measure_group.rb
@@ -5,7 +5,7 @@ require 'json'
 module MeasureRepositoryServiceTestKit
   # tests for read by ID and search for Measure service
   class MeasureGroup < Inferno::TestGroup
-    title 'Measure Group'
+    title 'Measure Read by Id and Search'
     description 'Ensure measure repository service can retrieve Measure resources by the server-defined id and search'
     id 'measure_group'
 

--- a/lib/measure_repository_service_test_kit/measure_group.rb
+++ b/lib/measure_repository_service_test_kit/measure_group.rb
@@ -20,6 +20,7 @@ module MeasureRepositoryServiceTestKit
       id 'read-by-id-measure-01'
       description %(This test verifies that the Measure resource can be read from the server.)
       input :measure_id, title: 'Measure id'
+      output :measure_id
 
       run do
         fhir_read(:measure, measure_id)

--- a/lib/measure_repository_service_test_kit/measure_group.rb
+++ b/lib/measure_repository_service_test_kit/measure_group.rb
@@ -5,7 +5,7 @@ require 'json'
 module MeasureRepositoryServiceTestKit
   # tests for read by ID and search for Measure service
   class MeasureGroup < Inferno::TestGroup
-    title 'Measure Repository Service Measure Group'
+    title 'Measure Group'
     description 'Ensure measure repository service can retrieve Measure resources by the server-defined id and search'
     id 'measure_group'
 

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -6,6 +6,8 @@ require_relative '../utils/package_utils'
 module MeasureRepositoryServiceTestKit
   # tests for Measure $package service
   class MeasurePackage < Inferno::TestGroup
+    include PackageUtils
+
     title 'Measure $package'
     description 'Ensure measure repository service can execute the $package operation to the Measure endpoint'
     id 'measure_package'
@@ -13,15 +15,75 @@ module MeasureRepositoryServiceTestKit
     fhir_client do
       url :url
     end
+    test do
+      title '200 response and JSON Bundle body for POST by id in url'
+      id 'measure-package-01'
+      description 'returned response has status code 200 and valid JSON FHIR Bundle in body'
+      input :selected_measure_id
+      makes_request :measure_package
+      run do
+        fhir_operation("Measure/#{selected_measure_id}/$package", name: :measure_package)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(measure_in_bundle(selected_measure_id, 'id', resource))
+      end
+    end
+
+    test do
+      title '200 response and JSON Bundle body for POST by url in body'
+      id 'measure-package-02'
+      description 'returned response has status code 200 and valid JSON FHIR Bundle in body'
+      input :selected_measure_url
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            {	name: 'identifier',
+              valueUrl: selected_measure_url }
+          ]
+        }
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation("Measure/$package", body: params)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(measure_in_bundle(selected_measure_url, 'url', resource))
+      end
+    end
+
+    test do
+      title '200 response and JSON Bundle body for POST by url in body'
+      id 'measure-package-02'
+      description 'returned response has status code 200 and valid JSON FHIR Bundle in body'
+      input :selected_measure_url
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            {	name: 'url',
+              valueUrl: selected_measure_url }
+          ]
+        }
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation("Measure/$package", body: params)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(measure_in_bundle(selected_measure_url, 'url', resource))
+      end
+    end
 
     test do
       title 'All related artifacts present'
-      id 'measure-package-01'
+      id 'measure-package-03'
       description 'returned bundle includes all related artifacts for all libraries'
       input :selected_measure_id
+      uses_request :measure_package
       run do
-        #fhir_operation("Measure/#{selected_measure_id}/$package")
-        #assert_related_artifacts_present(response[:body])
+        assert(related_artifacts_present(resource))
       end
     end
   end

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -39,21 +39,28 @@ module MeasureRepositoryServiceTestKit
       description 'returned response has status code 200 and included Measure matches parameters url,
       identifier, and version. Verifies the server supports SHALL parameters for the operation'
       input :measure_url, title: 'Measure url'
-      input :measure_identifier, title: 'Measure identifier'
-      input :measure_version, title: 'Measure version'
+      input :measure_identifier, optional: true, title: 'Measure identifier'
+      input :measure_version, optional: true, title: 'Measure version'
 
       run do
         params_hash = {
           resourceType: 'Parameters',
           parameter: [
             {	name: 'url',
-              valueUrl: measure_url },
-            {	name: 'identifier',
-              valueString: measure_identifier },
-            { name: 'version',
-              valueString: measure_version }
+              valueUrl: measure_url }
           ]
-        }.freeze
+        }
+        unless measure_identifier.nil?
+          params_hash[:parameter].append({	name: 'identifier',
+                                           valueString: measure_identifier })
+        end
+        unless measure_version.nil?
+          params_hash[:parameter].append({ name: 'version',
+                                           valueString: measure_version })
+        end
+
+        params_hash.freeze
+
         params = FHIR::Parameters.new params_hash
 
         fhir_operation('Measure/$package', body: params)
@@ -62,8 +69,8 @@ module MeasureRepositoryServiceTestKit
         assert_valid_json(response[:body])
         measure = retrieve_measure_from_bundle(measure_url, 'url', resource)
         assert(!measure.nil?)
-        assert(measure_has_matching_identifier?(measure, measure_identifier))
-        assert(measure.version == measure_version)
+        assert(measure_has_matching_identifier?(measure, measure_identifier)) unless measure_identifier.nil?
+        assert(measure.version == measure_version) unless measure_version.nil?
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -15,6 +15,7 @@ module MeasureRepositoryServiceTestKit
     fhir_client do
       url :url
     end
+
     test do
       title '200 response and JSON Bundle body for POST by id in url'
       id 'measure-package-01'
@@ -31,6 +32,7 @@ module MeasureRepositoryServiceTestKit
       end
     end
 
+    # rubocop:disable Metrics/BlockLength
     test do
       title '200 response and JSON Bundle body for POST by url, identifier, and version in body'
       id 'measure-package-02'
@@ -59,10 +61,11 @@ module MeasureRepositoryServiceTestKit
         assert_valid_json(response[:body])
         measure = retrieve_measure_from_bundle(selected_measure_url, 'url', resource)
         assert(!measure.nil?)
-        assert(measure_has_identifier(measure, selected_measure_identifier))
+        assert(measure_has_identifier?(measure, selected_measure_identifier))
         assert(measure.version == selected_measure_version)
       end
     end
+    # rubocop:enable Metrics/BlockLength
 
     test do
       title 'All related artifacts present'
@@ -71,7 +74,7 @@ module MeasureRepositoryServiceTestKit
       input :selected_measure_id
       uses_request :measure_package
       run do
-        assert(related_artifacts_present(resource))
+        assert(related_artifacts_present?(resource))
       end
     end
 

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../utils/package_utils'
+
+module MeasureRepositoryServiceTestKit
+  # tests for Measure $package service
+  class MeasurePackage < Inferno::TestGroup
+    title 'Measure $package'
+    description 'Ensure measure repository service can execute the $package operation to the Measure endpoint'
+    id 'measure_package'
+
+    fhir_client do
+      url :url
+    end
+
+    test do
+      title 'All related artifacts present'
+      id 'measure-package-01'
+      description 'returned bundle includes all related artifacts for all libraries'
+      input :selected_measure_id
+      run do
+        #fhir_operation("Measure/#{selected_measure_id}/$package")
+        #assert_related_artifacts_present(response[:body])
+      end
+    end
+  end
+end

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -20,14 +20,14 @@ module MeasureRepositoryServiceTestKit
       title '200 response and JSON Bundle body for POST by id in url'
       id 'measure-package-01'
       description 'returned response has status code 200 and valid JSON FHIR Bundle in body'
-      input :selected_measure_id
+      input :measure_id , title: 'Measure id' 
       makes_request :measure_package
       run do
-        fhir_operation("Measure/#{selected_measure_id}/$package", name: :measure_package)
+        fhir_operation("Measure/#{measure_id}/$package", name: :measure_package)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
-        measure = retrieve_measure_from_bundle(selected_measure_id, 'id', resource)
+        measure = retrieve_measure_from_bundle(measure_id, 'id', resource)
         assert(!measure.nil?)
       end
     end
@@ -37,20 +37,20 @@ module MeasureRepositoryServiceTestKit
       title '200 response and JSON Bundle body for POST by url, identifier, and version in body'
       id 'measure-package-02'
       description 'returned response has status code 200 and included Measure matches url, identifier, and version'
-      input :selected_measure_url
-      input :selected_measure_identifier
-      input :selected_measure_version
+      input :measure_url, title: 'Measure url' 
+      input :measure_identifier, title: 'Measure identifier' 
+      input :measure_version, title: 'Measure version' 
 
       run do
         params_hash = {
           resourceType: 'Parameters',
           parameter: [
             {	name: 'url',
-              valueUrl: selected_measure_url },
+              valueUrl: measure_url },
             {	name: 'identifier',
-              valueString: selected_measure_identifier },
+              valueString: measure_identifier },
             { name: 'version',
-              valueString: selected_measure_version }
+              valueString: measure_version }
           ]
         }
         params = FHIR::Parameters.new params_hash
@@ -59,10 +59,10 @@ module MeasureRepositoryServiceTestKit
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
-        measure = retrieve_measure_from_bundle(selected_measure_url, 'url', resource)
+        measure = retrieve_measure_from_bundle(measure_url, 'url', resource)
         assert(!measure.nil?)
-        assert(measure_has_identifier?(measure, selected_measure_identifier))
-        assert(measure.version == selected_measure_version)
+        assert(measure_has_identifier?(measure, measure_identifier))
+        assert(measure.version == measure_version)
       end
     end
     # rubocop:enable Metrics/BlockLength
@@ -71,7 +71,7 @@ module MeasureRepositoryServiceTestKit
       title 'All related artifacts present'
       id 'measure-package-03'
       description 'returned bundle includes all related artifacts for all libraries'
-      input :selected_measure_id
+      input :measure_id, title: 'Measure id' 
       uses_request :measure_package
       run do
         assert(related_artifacts_present?(resource))

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -5,6 +5,7 @@ require_relative '../utils/package_utils'
 
 module MeasureRepositoryServiceTestKit
   # tests for Measure $package service
+  # rubocop:disable Metrics/ClassLength
   class MeasurePackage < Inferno::TestGroup
     include PackageUtils
 
@@ -28,19 +29,15 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         measure = retrieve_measure_from_bundle(measure_id, 'id', resource)
-        assert(!measure.nil?, "No measure found in bundle with id: #{measure_id}")
+        assert(!measure.nil?, "No Measure found in bundle with id: #{measure_id}")
       end
     end
 
-    # rubocop:disable Metrics/BlockLength
     test do
-      title '200 response and JSON Bundle body for POST parameters url, identifier, and version in body'
+      title '200 response and JSON Bundle body for POST with url in body'
       id 'measure-package-02'
-      description 'returned response has status code 200 and included Measure matches parameters url,
-      identifier, and version. Verifies the server supports SHALL parameters for the operation'
+      description 'returned response has status code 200 and included Measure matches url parameter.'
       input :measure_url, title: 'Measure url'
-      input :measure_identifier, optional: true, title: 'Measure identifier'
-      input :measure_version, optional: true, title: 'Measure version'
 
       run do
         params_hash = {
@@ -49,11 +46,66 @@ module MeasureRepositoryServiceTestKit
             {	name: 'url',
               valueUrl: measure_url }
           ]
+        }.freeze
+
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation('Measure/$package', body: params)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        measure = retrieve_measure_from_bundle(measure_url, 'url', resource)
+        assert(!measure.nil?, "No Measure found in bundle with url: #{measure_url}")
+      end
+    end
+
+    test do
+      title '200 response and JSON Bundle body for POST with identifier in body'
+      id 'measure-package-03'
+      description 'returned response has status code 200 and included Measure matches identifier parameter.'
+      input :measure_identifier, title: 'Measure Identifier'
+
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            {	name: 'identifier',
+              valueString: measure_identifier }
+          ]
+        }.freeze
+
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation('Measure/$package', body: params)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        measure = retrieve_measure_from_bundle(measure_identifier, 'identifier', resource)
+        assert(!measure.nil?, "No Measure found in bundle with identifier: #{measure_identifier}")
+      end
+    end
+
+    # rubocop:disable Metrics/BlockLength
+    test do
+      title '200 response and JSON Bundle body for POST parameters url, identifier, and version in body and id in url'
+      id 'measure-package-04'
+      description 'returned response has status code 200 and included Measure matches parameters url,
+      identifier, and version. Verifies the server supports SHALL parameters for the operation'
+      input :measure_id, title: 'Measure id'
+      input :measure_url, title: 'Measure url'
+      input :measure_identifier, title: 'Measure identifier'
+      input :measure_version, optional: true, title: 'Measure version'
+
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            {	name: 'url',
+              valueUrl: measure_url },
+            {	name: 'identifier',
+              valueString: measure_identifier }
+          ]
         }
-        unless measure_identifier.nil?
-          params_hash[:parameter].append({	name: 'identifier',
-                                           valueString: measure_identifier })
-        end
         unless measure_version.nil?
           params_hash[:parameter].append({ name: 'version',
                                            valueString: measure_version })
@@ -63,21 +115,27 @@ module MeasureRepositoryServiceTestKit
 
         params = FHIR::Parameters.new params_hash
 
-        fhir_operation('Measure/$package', body: params)
+        fhir_operation("Measure/#{measure_id}/$package", body: params)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         measure = retrieve_measure_from_bundle(measure_url, 'url', resource)
         assert(!measure.nil?)
-        assert(measure_has_matching_identifier?(measure, measure_identifier)) unless measure_identifier.nil?
-        assert(measure.version == measure_version) unless measure_version.nil?
+        assert(measure.id == measure_id,
+               "No Measure found in bundle with id: #{measure_id}")
+        assert(measure_has_matching_identifier?(measure, measure_identifier),
+               "No Measure found in bundle with idendifier: #{measure_identifier}")
+        unless measure_version.nil?
+          assert(measure.version == measure_version,
+                 "No Measure found in bundle with version: #{measure_version}")
+        end
       end
     end
     # rubocop:enable Metrics/BlockLength
 
     test do
       title 'All related artifacts present'
-      id 'measure-package-03'
+      id 'measure-package-05'
       description 'returned bundle includes all related artifacts for all libraries'
       input :measure_id, title: 'Measure id'
       uses_request :measure_package
@@ -88,7 +146,7 @@ module MeasureRepositoryServiceTestKit
 
     test do
       title 'Throws 404 when no Measure on server matches id'
-      id 'measure-package-04'
+      id 'measure-package-06'
       description 'returns 404 status code with OperationOutcome when no Measure exists with passed-in id'
 
       run do
@@ -102,7 +160,7 @@ module MeasureRepositoryServiceTestKit
 
     test do
       title 'Throws 400 when no id, url, or identifier provided'
-      id 'measure-package-05'
+      id 'measure-package-07'
       description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
 
       run do
@@ -114,4 +172,5 @@ module MeasureRepositoryServiceTestKit
       end
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -20,7 +20,7 @@ module MeasureRepositoryServiceTestKit
       title '200 response and JSON Bundle body for POST by id in url'
       id 'measure-package-01'
       description 'returned response has status code 200 and valid JSON FHIR Bundle in body'
-      input :measure_id , title: 'Measure id' 
+      input :measure_id, title: 'Measure id'
       makes_request :measure_package
       run do
         fhir_operation("Measure/#{measure_id}/$package", name: :measure_package)
@@ -37,9 +37,9 @@ module MeasureRepositoryServiceTestKit
       title '200 response and JSON Bundle body for POST by url, identifier, and version in body'
       id 'measure-package-02'
       description 'returned response has status code 200 and included Measure matches url, identifier, and version'
-      input :measure_url, title: 'Measure url' 
-      input :measure_identifier, title: 'Measure identifier' 
-      input :measure_version, title: 'Measure version' 
+      input :measure_url, title: 'Measure url'
+      input :measure_identifier, title: 'Measure identifier'
+      input :measure_version, title: 'Measure version'
 
       run do
         params_hash = {
@@ -71,7 +71,7 @@ module MeasureRepositoryServiceTestKit
       title 'All related artifacts present'
       id 'measure-package-03'
       description 'returned bundle includes all related artifacts for all libraries'
-      input :measure_id, title: 'Measure id' 
+      input :measure_id, title: 'Measure id'
       uses_request :measure_package
       run do
         assert(related_artifacts_present?(resource))

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -26,53 +26,41 @@ module MeasureRepositoryServiceTestKit
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
-        assert(measure_in_bundle(selected_measure_id, 'id', resource))
+        measure = retrieve_measure_from_bundle(selected_measure_id, 'id', resource)
+        assert(!measure.nil?)
       end
     end
 
     test do
-      title '200 response and JSON Bundle body for POST by url in body'
+      title '200 response and JSON Bundle body for POST by url, identifier, and version in body'
       id 'measure-package-02'
-      description 'returned response has status code 200 and valid JSON FHIR Bundle in body'
+      description 'returned response has status code 200 and included Measure matches url, identifier, and version'
       input :selected_measure_url
-      run do
-        params_hash = {
-          resourceType: 'Parameters',
-          parameter: [
-            {	name: 'identifier',
-              valueUrl: selected_measure_url }
-          ]
-        }
-        params = FHIR::Parameters.new params_hash
+      input :selected_measure_identifier
+      input :selected_measure_version
 
-        fhir_operation("Measure/$package", body: params)
-        assert_response_status(200)
-        assert_resource_type(:bundle)
-        assert_valid_json(response[:body])
-        assert(measure_in_bundle(selected_measure_url, 'url', resource))
-      end
-    end
-
-    test do
-      title '200 response and JSON Bundle body for POST by url in body'
-      id 'measure-package-02'
-      description 'returned response has status code 200 and valid JSON FHIR Bundle in body'
-      input :selected_measure_url
       run do
         params_hash = {
           resourceType: 'Parameters',
           parameter: [
             {	name: 'url',
-              valueUrl: selected_measure_url }
+              valueUrl: selected_measure_url },
+            {	name: 'identifier',
+              valueString: selected_measure_identifier },
+            { name: 'version',
+              valueString: selected_measure_version }
           ]
         }
         params = FHIR::Parameters.new params_hash
 
-        fhir_operation("Measure/$package", body: params)
+        fhir_operation('Measure/$package', body: params)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
-        assert(measure_in_bundle(selected_measure_url, 'url', resource))
+        measure = retrieve_measure_from_bundle(selected_measure_url, 'url', resource)
+        assert(!measure.nil?)
+        assert(measure_has_identifier(measure, selected_measure_identifier))
+        assert(measure.version == selected_measure_version)
       end
     end
 
@@ -84,6 +72,34 @@ module MeasureRepositoryServiceTestKit
       uses_request :measure_package
       run do
         assert(related_artifacts_present(resource))
+      end
+    end
+
+    test do
+      title 'Throws 404 when no Measure on server matches id'
+      id 'measure-package-04'
+      description 'returns 404 status code with OperationOutcome when no Measure exists with passed-in id'
+
+      run do
+        fhir_operation('Measure/INVALID_ID/$package')
+        assert_response_status(404)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Throws 400 when no id, url, or identifier provided'
+      id 'measure-package-05'
+      description 'returns 400 status code with OperationOutcome when no id or url provided'
+
+      run do
+        fhir_operation('Measure/$package')
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
       end
     end
   end

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module DEQMTestKit
+  # Utility functions in support of the $package test group
+  module PackageUtils
+    def assert_related_artifacts_present(bundle)
+      artifact_urls = Set[]
+      bundle.entry.each do |e|
+        next unless e.resource.resourceType == 'Library'
+
+        e.relatedArtifact.each do |ra|
+          artifact_urls.add(ra.url) if ra.type == 'depends-on'
+        end
+      end
+      all_urls_present = artifact_urls.all? do |url|
+        bundle.entry.any? do |e|
+          e.resource.url == url
+        end
+      end
+      assert(all_urls_present)
+    end
+  end
+end

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'set'
 
 module MeasureRepositoryServiceTestKit

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -36,14 +36,23 @@ module MeasureRepositoryServiceTestKit
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
     def retrieve_measure_from_bundle(measure_iden, iden_type, bundle)
-      entry = bundle.entry.find do |e|
-        e.resource.resourceType == 'Measure' && e.resource.send(iden_type) == measure_iden
-      end
+      entry =
+        bundle.entry.find do |e|
+          if e.resource.resourceType == 'Measure'
+            if iden_type == 'identifier'
+              measure_has_matching_identifier?(e.resource, measure_iden)
+            else
+              e.resource.send(iden_type) == measure_iden
+            end
+          end
+        end
       return unless entry
 
       entry.resource
     end
+    # rubocop:enable Metrics/MethodLength
 
     # rubocop:disable Metrics/CyclomaticComplexity
     def measure_has_matching_identifier?(measure, identifier)

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -1,25 +1,38 @@
 # frozen_string_literal: true
 
+require 'pry'
 require 'set'
 
-module DEQMTestKit
+module MeasureRepositoryServiceTestKit
   # Utility functions in support of the $package test group
   module PackageUtils
-    def assert_related_artifacts_present(bundle)
+    def related_artifacts_present(bundle)
       artifact_urls = Set[]
       bundle.entry.each do |e|
         next unless e.resource.resourceType == 'Library'
 
-        e.relatedArtifact.each do |ra|
-          artifact_urls.add(ra.url) if ra.type == 'depends-on'
+        e.resource.relatedArtifact.each do |ra|
+          if ra.type == 'depends-on' && ra.resource.include?('Library') && ra.resource != 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+            artifact_urls.add(ra.resource)
+          end
         end
       end
-      all_urls_present = artifact_urls.all? do |url|
+      artifact_urls.all? do |url|
+        if url.include? '|'
+          split_reference = url.split('|')
+          url = split_reference[0]
+          version = split_reference[1]
+        end
         bundle.entry.any? do |e|
-          e.resource.url == url
+          e.resource.url == url && e.resource.version == version
         end
       end
-      assert(all_urls_present)
+    end
+
+    def measure_in_bundle(measure_iden, iden_type, bundle)
+      bundle.entry.any? do |e|
+        e.resource.resourceType == 'Measure' && e.resource.send(iden_type) == measure_iden
+      end
     end
   end
 end

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -46,7 +46,7 @@ module MeasureRepositoryServiceTestKit
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
-    def measure_has_identifier?(measure, identifier)
+    def measure_has_matching_identifier?(measure, identifier)
       sys, value = split_identifier(identifier)
       measure.identifier.any? do |iden|
         does_match = true

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -29,9 +29,38 @@ module MeasureRepositoryServiceTestKit
       end
     end
 
-    def measure_in_bundle(measure_iden, iden_type, bundle)
-      bundle.entry.any? do |e|
+    def retrieve_measure_from_bundle(measure_iden, iden_type, bundle)
+      entry = bundle.entry.find do |e|
         e.resource.resourceType == 'Measure' && e.resource.send(iden_type) == measure_iden
+      end
+      return unless entry
+
+      entry.resource
+    end
+
+    def measure_has_identifier(measure, identifier)
+      iden_split = identifier.split('|')
+      value = nil
+      sys = nil
+      if iden_split.length == 1
+        value = iden_split[0]
+      elsif iden_split[0] == ''
+        value = iden_split[1]
+      elsif iden_split[1] == ''
+        sys = iden_split[0]
+      else
+        sys = iden_split[0]
+        value = iden_split[1]
+      end
+      puts sys
+      puts value
+      measure.identifier.any? do |iden|
+        puts iden.system
+        puts iden.value
+        does_match = true
+        does_match &&= iden.value == value if !iden.value.nil? && value
+        does_match &&= iden.system == sys if !iden.system.nil? && sys
+        does_match
       end
     end
   end

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-
-require 'pry'
 require 'set'
 
 module MeasureRepositoryServiceTestKit

--- a/spec/measure_package_spec.rb
+++ b/spec/measure_package_spec.rb
@@ -184,6 +184,11 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       result = run(test, url:, selected_measure_id:)
       expect(result.result).to eq('fail')
     end
+
+    it 'skips if measure_package request has not been made' do
+      result = run(test, url:, selected_measure_id:)
+      expect(result.result).to eq('skip')
+    end
   end
   describe 'Server returns 404 when no measure matches id' do
     let(:test) { group.tests[3] }

--- a/spec/measure_package_spec.rb
+++ b/spec/measure_package_spec.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('measure_repository_service_test_suite') }
+  let(:group) { suite.groups[1] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:url) { 'http://example.com/fhir' }
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(test_session_id: test_session.id, name:, value:, type: 'text')
+    end
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+  end
+
+  describe 'Server successfully returns bundle on Measure $package with id in url' do
+    let(:test) { group.tests.first }
+    let(:selected_measure_id) { 'measure_id' }
+
+    it 'passes if a 200 is returned with bundle body and id matches' do
+      measure = FHIR::Measure.new(id: selected_measure_id)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :post,
+        "#{url}/Measure/#{selected_measure_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, selected_measure_id:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not returned' do
+      measure = FHIR::Measure.new(id: selected_measure_id)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :post,
+        "#{url}/Measure/#{selected_measure_id}/$package"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, selected_measure_id:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if body is not a Bundle' do
+      measure = FHIR::Measure.new(id: selected_measure_id)
+      stub_request(
+        :post,
+        "#{url}/Measure/#{selected_measure_id}/$package"
+      ).to_return(status: 400, body: measure.to_json)
+
+      result = run(test, url:, selected_measure_id:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Measure in returned bundle does not match id' do
+      measure = FHIR::Measure.new(id: 'invalid')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :post,
+        "#{url}/Measure/#{selected_measure_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, selected_measure_id:)
+      expect(result.result).to eq('fail')
+    end
+  end
+  describe 'Server successfully returns bundle on Measure $package with url, identifier, and version in body' do
+    let(:test) { group.tests[1] }
+    let(:selected_measure_id) { 'measure_id' }
+    let(:selected_measure_identifier) { 'identifier_system|identifier_value' }
+    let(:selected_measure_url) { 'measure_url' }
+    let(:selected_measure_version) { 'measure_version' }
+    let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
+
+    it 'passes if a 200 is returned with bundle body and all fields match' do
+      measure = FHIR::Measure.new(url: selected_measure_url, identifier: expected_identifier,
+                                  version: selected_measure_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+      result = run(test, url:, selected_measure_url:, selected_measure_identifier:, selected_measure_version:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is returned with bundle body but url does not match' do
+      measure = FHIR::Measure.new(url: selected_measure_url, identifier: expected_identifier,
+                                  version: selected_measure_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+      result = run(test, url:, selected_measure_url: 'invalid_url', selected_measure_identifier:,
+                         selected_measure_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if a 200 is returned with bundle body but version does not match' do
+      measure = FHIR::Measure.new(url: selected_measure_url, identifier: expected_identifier,
+                                  version: selected_measure_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+      result = run(test, url:, selected_measure_url:, selected_measure_identifier:,
+                         selected_measure_version: 'invalid_version')
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if a 200 is returned with bundle body but identifier system does not match' do
+      measure = FHIR::Measure.new(url: selected_measure_url, identifier: expected_identifier,
+                                  version: selected_measure_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+      result = run(test, url:, selected_measure_url:, selected_measure_identifier: 'invalid_system|identifier_value',
+                         selected_measure_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if a 200 is returned with bundle body but identifier value does not match' do
+      measure = FHIR::Measure.new(url: selected_measure_url, identifier: expected_identifier,
+                                  version: selected_measure_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+
+      stub_request(
+        :post,
+        "#{url}/Measure/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+      result = run(test, url:, selected_measure_url:, selected_measure_identifier: 'identifier_system|invalid_value',
+                         selected_measure_version:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  #   describe 'Server successfully returns all referenced Library related artifacts' do
+  #     let(:test) { group.tests[2] }
+  #     let(:selected_measure_id) { 'measure_id' }
+  #     let(:measure) { FHIR::Measure.new(id: selected_measure_id, library: ['test-Library']) }
+  #     let(:library) do
+  #       FHIR::Library.new(url: 'test-Library', relatedArtifact: [{ type: 'depends-on', resource: 'dep-Library' }])
+  #     end
+  #     let(:dep_library) { FHIR::Library.new(url: 'dep-Library') }
+  #     it 'passes if all related artifacts are present' do
+  #       bundle = FHIR::Bundle.new(total: 3,
+  #                                 entry: [{ resource: measure }, { resource: library },
+  #                                         { resource: dep_library }])
+  #       stub_request(
+  #         :post,
+  #         "#{url}/Measure/#{selected_measure_id}/$package"
+  #       ).to_return(status: 200, body: bundle.to_json)
+  #       result = run(test, url:, selected_measure_id:, uses_request:)
+  #       expect(result.result).to eq('pass')
+  #     end
+  #   end
+  describe 'Server returns 404 when no measure matches id' do
+    let(:test) { group.tests[3] }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+    it 'passes when 404 returned with OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$package"
+      ).to_return(status: 404, body: error_outcome.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if 200 status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$package"
+      ).to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if bundle returned' do
+      bundle = FHIR::Bundle.new
+      stub_request(
+        :post,
+        "#{url}/Measure/INVALID_ID/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server returns 400 when no id, url, or identifier provided' do
+    let(:test) { group.tests[4] }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+    it 'passes when 404 returned with OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$package"
+      ).to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if 200 status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Measure/$package"
+      ).to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if bundle status code returned' do
+      bundle = FHIR::Bundle.new
+      stub_request(
+        :post,
+        "#{url}/Measure/$package"
+      ).to_return(status: 400, body: bundle.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+end

--- a/spec/measure_repository_service_test_kit/measure_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_package_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       expect(result.result).to eq('fail')
     end
   end
-  
+
   describe 'Server successfully returns bundle on Measure $package with url, identifier, and version in body' do
     let(:test) { group.tests[1] }
     let(:measure_id) { 'measure_id' }

--- a/spec/measure_repository_service_test_kit/measure_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_package_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       expect(result.result).to eq('pass')
     end
 
-    it 'fails if a 200 is returned with bundle body but url does not match' do
+    it 'fails if a 200 is returned with bundle body but id does not match' do
       measure = FHIR::Measure.new(id: 'invalid_id', url: measure_url, identifier: expected_identifier,
                                   version: measure_version)
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])

--- a/spec/measure_repository_service_test_kit/measure_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_package_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       FHIR::Library.new(url: 'test-Library', relatedArtifact: [{ type: 'depends-on', resource: 'dep-Library' }])
     end
     let(:dep_library) { FHIR::Library.new(url: 'dep-Library') }
+
     it 'passes if all related artifacts are present' do
       bundle = FHIR::Bundle.new(total: 3,
                                 entry: [{ resource: measure }, { resource: library },
@@ -222,7 +223,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     let(:test) { group.tests[4] }
     let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 
-    it 'passes when 404 returned with OperationOutcome' do
+    it 'passes when 400 returned with OperationOutcome' do
       stub_request(
         :post,
         "#{url}/Measure/$package"

--- a/spec/measure_repository_service_test_kit/measure_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_package_spec.rb
@@ -243,7 +243,8 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     end
 
     it 'fails if a 200 is returned with bundle body but identifier system does not match' do
-      measure = FHIR::Measure.new(id: measure_id, url: measure_url, identifier: { system: 'invalid_system', value: 'identifier_value' },
+      measure = FHIR::Measure.new(id: measure_id, url: measure_url, identifier: { system: 'invalid_system',
+                                                                                  value: 'identifier_value' },
                                   version: measure_version)
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
 
@@ -257,7 +258,8 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     end
 
     it 'fails if a 200 is returned with bundle body but identifier value does not match' do
-      measure = FHIR::Measure.new(id: measure_id, url: measure_url, identifier: { system: 'identifier_system', value: 'invalid_value' },
+      measure = FHIR::Measure.new(id: measure_id, url: measure_url, identifier: { system: 'identifier_system',
+                                                                                  value: 'invalid_value' },
                                   version: measure_version)
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
 


### PR DESCRIPTION
# Summary
We now have a test suite for all Measure $package behavior!

## New behavior
New `Measure/$package` suite to test all `Measure/$package` functionality

## Code changes
 - added `measure_package.rb` file with entire `Measure/$package` test suite
 - added `util/package_utils` for shared functions for more easily parsing `$package` responses
 - added rspec testing

# Testing guidance
 - `rspec` and `rubocop`
 - in `measure-repository-service`: 
 ```
 git clone https://github.com/cqframework/ecqm-content-r4-2021.git
 npm run db:reset
 npm run db:loadBundle "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json"
```
 - Start up `measure-repository-service` with `npm start`
 - Follow the directions in the `README.md` for local setup for the test kit
 - Navigate to `http://localhost:4567`
 - Click `run all tests`
 - Enter the following input for the respective field: 
 ```
FHIR Server Base Url (required) *: http://localhost:3000/4_0_1
selected_measure_id (required) *: ColorectalCancerScreeningsFHIR
selected_measure_url (required) *: http://ecqi.healthit.gov/ecqms/Measure/ColorectalCancerScreeningsFHIR
selected_measure_identifier (required) *: http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms|130FHIR
selected_measure_version (required) *:  0.0.003
```
 - Click submit and watch all the tests pass! (except capability statement)
 - Try the same except start up the test kit using docker, and change FHIR Server Base Url to `host.docker.internal:3000/4_0_1` and everything should still work
 - Take a close look at all rspec tests and make sure they adequately cover the test cases 
 - Take a look at the disabled Metrics and make sure those are appropriate
