### PR TITLE
Library $package suite

### DIFF
--- a/lib/measure_repository_service_test_kit.rb
+++ b/lib/measure_repository_service_test_kit.rb
@@ -3,6 +3,7 @@
 require_relative 'measure_repository_service_test_kit/measure_group'
 require_relative 'measure_repository_service_test_kit/library_group'
 require_relative 'measure_repository_service_test_kit/measure_package'
+require_relative 'measure_repository_service_test_kit/library_package'
 
 module MeasureRepositoryServiceTestKit
   # Overall test suite
@@ -54,5 +55,6 @@ module MeasureRepositoryServiceTestKit
     group from: :measure_group
     group from: :library_group
     group from: :measure_package
+    group from: :library_package
   end
 end

--- a/lib/measure_repository_service_test_kit/library_package.rb
+++ b/lib/measure_repository_service_test_kit/library_package.rb
@@ -113,7 +113,7 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         library = retrieve_root_library_from_bundle(library_url, 'url', resource)
-        assert(!library.nil?)
+        assert(!library.nil?, "No Library found in bundle with url: #{library_url}")
         assert(library.id == library_id, "No Library found in bundle with id: #{library_id}")
         assert(resource_has_matching_identifier?(library, library_identifier),
                "No Library found in bundle with identifier: #{library_identifier}")

--- a/lib/measure_repository_service_test_kit/library_package.rb
+++ b/lib/measure_repository_service_test_kit/library_package.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../utils/package_utils'
+
+module MeasureRepositoryServiceTestKit
+  # tests for Library $package service
+  # rubocop:disable Metrics/ClassLength
+  class LibraryPackage < Inferno::TestGroup
+    include PackageUtils
+
+    title 'Library $package'
+    description 'Ensure measure repository service can execute the $package operation to the Library endpoint'
+    id 'library_package'
+
+    fhir_client { url :url }
+
+    test do
+      title '200 response and JSON Bundle body for POST by id in url'
+      id 'library-package-01'
+      description 'returned response has status code 200 and valid JSON FHIR Bundle in body'
+      input :library_id, title: 'Library id'
+      makes_request :library_package
+      run do
+        fhir_operation("Library/#{library_id}/$package", name: :library_package)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        library = retrieve_root_library_from_bundle(library_id, 'id', resource)
+        assert(!library.nil?, "No Library found in bundle with id: #{library_id}")
+      end
+    end
+
+    test do
+      title '200 response and JSON Bundle body for POST with url in body'
+      id 'library-package-02'
+      description 'returned resopnse has status code 200 and included Library matches url parameter.'
+      input :library_url, title: 'Library url'
+
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'url',
+              valueUrl: library_url }
+          ]
+        }.freeze
+
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation('Library/$package', body: params)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        library = retrieve_root_library_from_bundle(library_url, 'url', resource)
+        assert(!library.nil?, "No Library found in bundle with url: #{library_url}")
+      end
+    end
+
+    test do
+      title '200 response and JSON Bundle body for POST with identifier in body'
+      id 'library-package-03'
+      description 'returned response has status code 200 and included Library matches identifier parameter.'
+      input :library_identifier, title: 'Library Identifier'
+
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'identifier',
+              valueString: library_identifier }
+          ]
+        }.freeze
+
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation('Library/$package', body: params)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        library = retrieve_root_library_from_bundle(library_identifier, 'identifier', resource)
+        assert(!library.nil?, "No Library found in bundle with identifier: #{library_identifier}")
+      end
+    end
+
+    # rubocop:disable Metrics/BlockLength
+    test do
+      title '200 response and JSON Bundle body for POST parameters url, identifier, and version in body and id in url'
+      id 'library-package-04'
+      description 'returned repsonse has status code 200 and included Library matches parameters url,
+      identifier, and version. Verifies the server supports SHALL parameters for the operation'
+      input :library_id, title: 'Library id'
+      input :library_url, title: 'Library url'
+      input :library_identifier, title: 'Library identifier'
+      input :library_version, optional: true, title: 'Library version'
+
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'url', valueUrl: library_url },
+            { name: 'identifier', valueString: library_identifier }
+          ]
+        }
+        params_hash[:parameter].append({ name: 'version', valueString: library_version }) unless library_version.nil?
+
+        params_hash.freeze
+
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation("Library/#{library_id}/$package", body: params)
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        library = retrieve_root_library_from_bundle(library_url, 'url', resource)
+        assert(!library.nil?)
+        assert(library.id == library_id, "No Library found in bundle with id: #{library_id}")
+        assert(resource_has_matching_identifier?(library, library_identifier),
+               "No Library found in bundle with identifier: #{library_identifier}")
+        unless library_version.nil?
+          assert(library.version == library_version, "No Library found in bundle with version: #{library_version}")
+        end
+      end
+    end
+    # rubocop:enable Metrics/BlockLength
+
+    test do
+      title 'All related artifacts present'
+      id 'library-package-05'
+      description 'returned bundle includes all related artifacts for all libraries'
+      input :library_id, title: 'Library id'
+      uses_request :library_package
+
+      run do
+        assert(related_artifacts_present?(resource))
+      end
+    end
+
+    test do
+      title 'Throws 404 when no Library on server matches id'
+      id 'library-package-06'
+      description 'returns 404 status code with OperationOutcome when no Library exists with passed-in id'
+
+      run do
+        fhir_operation('Library/INVALID_ID/$package')
+        assert_response_status(404)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Throws 400 when no id, url, or identifier provided'
+      id 'library-package-07'
+      description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
+
+      run do
+        fhir_operation('Library/$package')
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -120,7 +120,7 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         measure = retrieve_measure_from_bundle(measure_url, 'url', resource)
-        assert(!measure.nil?)
+        assert(!measure.nil?, "No Measure found in bundle with url: #{measure_url}")
         assert(measure.id == measure_id,
                "No Measure found in bundle with id: #{measure_id}")
         assert(resource_has_matching_identifier?(measure, measure_identifier),

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -123,8 +123,8 @@ module MeasureRepositoryServiceTestKit
         assert(!measure.nil?)
         assert(measure.id == measure_id,
                "No Measure found in bundle with id: #{measure_id}")
-        assert(measure_has_matching_identifier?(measure, measure_identifier),
-               "No Measure found in bundle with idendifier: #{measure_identifier}")
+        assert(resource_has_matching_identifier?(measure, measure_identifier),
+               "No Measure found in bundle with identifier: #{measure_identifier}")
         unless measure_version.nil?
           assert(measure.version == measure_version,
                  "No Measure found in bundle with version: #{measure_version}")

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -42,7 +42,7 @@ module MeasureRepositoryServiceTestKit
         bundle.entry.find do |e|
           if e.resource.resourceType == 'Measure'
             if iden_type == 'identifier'
-              measure_has_matching_identifier?(e.resource, measure_iden)
+              resource_has_matching_identifier?(e.resource, measure_iden)
             else
               e.resource.send(iden_type) == measure_iden
             end
@@ -54,10 +54,28 @@ module MeasureRepositoryServiceTestKit
     end
     # rubocop:enable Metrics/MethodLength
 
+    # rubocop:disable Metrics/MethodLength
+    def retrieve_root_library_from_bundle(library_iden, iden_type, bundle)
+      entry =
+        bundle.entry.find do |e|
+          if e.resource.resourceType == 'Library'
+            if iden_type == 'identifier'
+              resource_has_matching_identifier?(e.resource, library_iden)
+            else
+              e.resource.send(iden_type) == library_iden
+            end
+          end
+        end
+      return unless entry
+
+      entry.resource
+    end
+    # rubocop:enable Metrics/MethodLength
+
     # rubocop:disable Metrics/CyclomaticComplexity
-    def measure_has_matching_identifier?(measure, identifier)
+    def resource_has_matching_identifier?(resource, identifier)
       sys, value = split_identifier(identifier)
-      measure.identifier.any? do |iden|
+      resource.identifier.any? do |iden|
         does_match = true
         does_match &&= iden.value == value if !iden.value.nil? && value
         does_match &&= iden.system == sys if !iden.system.nil? && sys

--- a/spec/measure_repository_service_test_kit/library_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_package_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
 
     it 'fails if a 200 is not returned' do
       library = FHIR::Library.new(url: library_url)
-      bundle = FHIR::Library.new(total: 1, entry: [{ reosurce: library }])
+      bundle = FHIR::Library.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
         "#{url}/Library/$package"
@@ -292,7 +292,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
     end
 
     it 'fails if related artifacts are missing' do
-      bundle = FHIR::Bundle.new(total: 2, entry: [{ resource: library }])
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       repo_create(
         :request,
         name: 'library_package',
@@ -369,7 +369,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       expect(result.result).to eq('fail')
     end
 
-    it 'fails if bundle status code returned' do
+    it 'fails if bundle body returned' do
       bundle = FHIR::Bundle.new
       stub_request(
         :post,

--- a/spec/measure_repository_service_test_kit/library_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_package_spec.rb
@@ -1,0 +1,382 @@
+# frozen_string_literal: true
+
+require_relative '../utils/spec_utils'
+
+RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('measure_repository_service_test_suite') }
+  let(:group) { suite.groups[4] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:url) { 'http://example.com/fhir' }
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+  describe 'Server successfully returns bundle on Library $package with id in url' do
+    let(:test) { group.tests.first }
+    let(:library_id) { 'library_id' }
+
+    it 'passes if a 200 is returned with bundle body and id matches' do
+      library = FHIR::Library.new(id: library_id)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not returned' do
+      library = FHIR::Library.new(id: library_id)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if body is not a Bundle' do
+      library = FHIR::Library.new(id: library_id)
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 400, body: library.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Library in returned bundle does not match id' do
+      library = FHIR::Library.new(id: 'invalid')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully returns bundle on Measure $package with url in body' do
+    let(:test) { group.tests[1] }
+    let(:library_url) { 'library_url' }
+
+    it 'passes if a 200 is returned with bundle body and url matches' do
+      library = FHIR::Library.new(url: library_url)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not returned' do
+      library = FHIR::Library.new(url: library_url)
+      bundle = FHIR::Library.new(total: 1, entry: [{ reosurce: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if body is not a Bundle' do
+      library = FHIR::Library.new(url: library_url)
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 400, body: library.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Library in returned Bundle does not match url' do
+      library = FHIR::Library.new(url: 'http://example.com/invalid')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully returns bundle on Library $package with identifier in body' do
+    let(:test) { group.tests[2] }
+    let(:library_identifier) { 'identifier_system|identifier_value' }
+    let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
+
+    it 'passes if a 200 is returned with bundle body and identifier matches' do
+      library = FHIR::Library.new(identifier: expected_identifier)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not returned' do
+      library = FHIR::Library.new(identifier: expected_identifier)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if body is not a Bundle' do
+      library = FHIR::Library.new(identifier: expected_identifier)
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 400, body: library.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Library in returned bundle does not match identifier system' do
+      library = FHIR::Library.new(identifier: { system: 'invalid_system', value: 'identifier_value' })
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Library in reutrned bundle does not match identifier value' do
+      library = FHIR::Library.new(identifier: { system: 'identifier_system', value: 'invalid_value' })
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully returns bundle on Library $package with url, identifier, and version in body' do
+    let(:test) { group.tests[3] }
+    let(:library_id) { 'library_id' }
+    let(:library_identifier) { 'identifier_system|identifier_value' }
+    let(:library_url) { 'library_url' }
+    let(:library_version) { 'library_version' }
+    let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
+
+    it 'passes if a 200 is returned with bundle body and all fields match' do
+      library = FHIR::Library.new(id: library_id, url: library_url, identifier: expected_identifier,
+                                  version: library_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is returned with bundle body but id does not match' do
+      library = FHIR::Library.new(id: 'invalid_id', url: library_url, identifier: expected_identifier,
+                                  version: library_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if a 200 is returned with bundle body but url does not match' do
+      library = FHIR::Library.new(id: library_id, url: 'invalid_url', identifier: expected_identifier,
+                                  version: library_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if a 200 is returned with bundle body but version does not match' do
+      library = FHIR::Library.new(id: library_id, url: library_url, identifier: expected_identifier,
+                                  version: 'invalid_version')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if a 200 is returned with bundle body but identifier system does not match' do
+      library = FHIR::Library.new(id: library_id, url: library_url,
+                                  identifier: { system: 'invalid_system', value: 'identifier_value' },
+                                  version: library_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if a 200 is returned with bundle body but identifier value does not match' do
+      library = FHIR::Library.new(id: library_id, url: library_url,
+                                  identifier: { system: 'identifier_system', value: 'invalid_value' },
+                                  version: library_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully returns all referenced Library related artifacts' do
+    let(:test) { group.tests[4] }
+    let(:library_id) { 'library_id' }
+    let(:library) do
+      FHIR::Library.new(url: 'test-Library', relatedArtifact: [{ type: 'depends-on', resource: 'dep-Library' }])
+    end
+    let(:dep_library) { FHIR::Library.new(url: 'dep-Library') }
+
+    it 'passes if all related artifacts are present' do
+      bundle = FHIR::Bundle.new(total: 2, entry: [{ resource: library }, { resource: dep_library }])
+      repo_create(
+        :request,
+        name: 'library_package',
+        url: "http://example.com/Library/#{library_id}/$package",
+        test_session_id: test_session.id,
+        status: 200,
+        response_body: bundle.to_json
+      )
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if related artifacts are missing' do
+      bundle = FHIR::Bundle.new(total: 2, entry: [{ resource: library }])
+      repo_create(
+        :request,
+        name: 'library_package',
+        url: "http://example.com/Library/#{library_id}/$package",
+        test_session_id: test_session.id,
+        status: 200,
+        response_body: bundle.to_json
+      )
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'skips if library_package request has not been made' do
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('skip')
+    end
+  end
+
+  describe 'Server returns 404 when no library matches id' do
+    let(:test) { group.tests[5] }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+    it 'passses when 404 returned with OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Library/INVALID_ID/$package"
+      ).to_return(status: 404, body: error_outcome.to_json)
+
+      result = run(test, url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if 200 status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/INVALID_ID/$package"
+      ).to_return(status: 200, body: error_outcome.to_json)
+
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if bundle returned' do
+      bundle = FHIR::Bundle.new
+      stub_request(
+        :post,
+        "#{url}/Library/INVALID_ID/$package"
+      ).to_return(status: 200, body: bundle.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server returns 400 when no id, url, or identifier provided' do
+    let(:test) { group.tests[6] }
+    let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+
+    it 'passes when 400 returned with OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if 200 status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if bundle status code returned' do
+      bundle = FHIR::Bundle.new
+      stub_request(
+        :post,
+        "#{url}/Library/$package"
+      ).to_return(status: 400, body: bundle.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+end

--- a/spec/measure_repository_service_test_kit/measure_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_package_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       expect(result.result).to eq('fail')
     end
 
-    it 'fails if bundle status code returned' do
+    it 'fails if bundle body returned' do
       bundle = FHIR::Bundle.new
       stub_request(
         :post,


### PR DESCRIPTION
# Summary
We now have a suite for all Library $package behavior.

## New behavior
- `Library/$package` suite to test all `Library/$package` functionality

## Code changes
- `lib/measure_repository_service_test_kit.rb` - new `library_package` test group added to the test kit
- `library_package.rb` - file with entire `Library/$package` test suite
- `measure_package.rb` - small typo / function name change
- `package_utils.rb` - change `measure_has_matching_identifier` to `resource_has_matching_identifier` so it applies to both `$package` operations. I also added `retrieve_root_library_from_bundle` but I can honestly just refactor `retrieve_measure_from_bundle` if people think that is a better idea? 
- `library_package_spec.rb` - rspec testing 

# Testing guidance
- `rspec` and `rubocop`
- in `measure-repository-service`:
 ```
 git clone https://github.com/cqframework/ecqm-content-r4-2021.git
 npm run db:reset
 npm run db:loadBundle "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json"
```
 - Start up `measure-repository-service` with `npm start`
 - Follow the directions in the `README.md` for local setup for the test kit
 - Navigate to `http://localhost:4567`
 - Click `run all tests`
 - Enter the following input for the respective field: 
 ```
FHIR Server Base Url (required) *: http://localhost:3000/4_0_1
selected_measure_id (required) *: ColorectalCancerScreeningsFHIR
selected_library_id (required) *: ColorectalCancerScreeningsFHIR
selected_measure_url (required) *: http://ecqi.healthit.gov/ecqms/Measure/ColorectalCancerScreeningsFHIR
selected_measure_identifier (required) *: http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms|130FHIR
selected_measure_version:  0.0.003
selected_library_url (required) *: http://ecqi.healthit.gov/ecqms/Library/ColorectalCancerScreeningsFHIR
selected_library_identifier (required) *: http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms|130FHIR
selected_library_version:  0.0.003
```
 - Click submit and watch all the tests pass **except** for two in the new `Library/$package` test suite. THIS IS EXPECTED! The EXM130 measure does not have any identifier's in its libraries so the tests with identifier should fail. Let me know if you think this is okay for now. I figured since identifier is a SHALL parameter we still want it to be required? Maybe? Let me know what you think. Regardless, this is what it should look like for now:

![image](https://user-images.githubusercontent.com/30158156/213300311-15b76c20-6a42-41f3-a392-bff65dc64a9b.png)

 - Try the same except start up the test kit using docker, and change FHIR Server Base Url to `host.docker.internal:3000/4_0_1` and everything should still work
 - Take a close look at all rspec tests and make sure they adequately cover the test cases 
 - Take a look at the disabled Metrics and make sure those are appropriate
 
NOTE: A lot of this is basically identical to Nat's [Measure/$package PR](https://github.com/projecttacoma/measure-repository-service-test-kit/pull/3) so that may be helpful to look at as well!