### PR TITLE
Search test group

### DIFF
--- a/lib/measure_repository_service_test_kit/library_group.rb
+++ b/lib/measure_repository_service_test_kit/library_group.rb
@@ -114,7 +114,7 @@ module MeasureRepositoryServiceTestKit
     end
 
     test do
-      title 'Server returns 200 response status and bundle that contains all the correct verisons of the library
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the library
       matching a name'
       id 'read-and-search-library-06'
       description %(This test verifies that a Library resource can be found through search by name from the server.)

--- a/lib/measure_repository_service_test_kit/library_group.rb
+++ b/lib/measure_repository_service_test_kit/library_group.rb
@@ -17,6 +17,13 @@ module MeasureRepositoryServiceTestKit
       url :url
     end
 
+    status_type_options = { list_options: [{ label: 'Active', value: 'active' },
+                                           { label: 'Draft', value: 'draft' },
+                                           { label: 'Retired', value: 'retired' },
+                                           { label: 'Unknown', value: 'unknown' }] }
+    status_type_args = { type: 'radio', optional: false, default: 'active', options: status_type_options,
+                         title: 'Status' }
+
     INVALID_ID = 'INVALID_ID'
 
     test do
@@ -156,7 +163,7 @@ module MeasureRepositoryServiceTestKit
       matching a status'
       id 'read-and-search-library-08'
       description %(This test verifies a Library resource can be found through search by status from the server.)
-      input :library_status, title: 'Library status'
+      input :library_status, **status_type_args
 
       run do
         fhir_search(:library, params: { status: library_status })

--- a/lib/measure_repository_service_test_kit/library_group.rb
+++ b/lib/measure_repository_service_test_kit/library_group.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'json'
+require_relative '../utils/package_utils'
 
 module MeasureRepositoryServiceTestKit
   # tests for read by ID and search for Library service
+  # rubocop:disable Metrics/ClassLength
   class LibraryGroup < Inferno::TestGroup
+    include PackageUtils
+
     title 'Library Read by Id and Search'
     description 'Ensure measure repository service can retrieve Library resources by the server-defined id and search'
     id 'library_group'
@@ -17,7 +21,7 @@ module MeasureRepositoryServiceTestKit
 
     test do
       title 'Server returns 200 response status and correct Library resource from the read interaction'
-      id 'read-by-id-library-01'
+      id 'read-and-search-library-01'
       description %(This test verifies that the Library resource can be read from the server.)
       input :library_id, title: 'Library id'
 
@@ -34,7 +38,7 @@ module MeasureRepositoryServiceTestKit
 
     test do
       title 'Server returns 404 response status when the resource is not available on the server'
-      id 'read-by-id-library-02'
+      id 'read-and-search-library-02'
       description %(This test verifies that the server appropriately returns 404 response status
                   for a resource whose id cannot be found in the server's database.)
 
@@ -47,5 +51,145 @@ module MeasureRepositoryServiceTestKit
         assert(resource.issue[0].severity == 'error')
       end
     end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the library
+      matching a url'
+      id 'read-and-search-library-03'
+      description %(This test verifies that a Library resource can be found through search by url from the server.)
+      input :library_url, title: 'Library url'
+
+      run do
+        fhir_search(:library, params: { url: library_url })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by url returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.url == library_url,
+               "Requested resource with url #{library_url}, received resource with
+               url #{resource.entry[0].resource.url}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the library
+      matching a version'
+      id 'read-and-search-library-04'
+      description %(This test verifies that a Library resource can be found through search by version from
+      the server.)
+      input :library_version, title: 'Library version'
+
+      run do
+        fhir_search(:library, params: { version: library_version })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by version returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.version == library_version, "Requested resource with
+        version #{library_version}, received resource with version #{resource.entry[0].resource.version}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the library
+      matching an identifier'
+      id 'read-and-search-library-05'
+      description %(This test verifies that a Library resource can be found through search by identifier from
+      the server.)
+      input :library_identifier, title: 'Library Identifier'
+
+      run do
+        fhir_search(:library, params: { identifier: library_identifier })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by identifier returned an empty FHIR searchset bundle')
+        assert resource_has_matching_identifier?(resource.entry[0].resource, library_identifier),
+               "Requested resource with identifier #{library_identifier}, received resource with identifier
+        #{resource.entry[0].resource.identifier}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct verisons of the library
+      matching a name'
+      id 'read-and-search-library-06'
+      description %(This test verifies that a Library resource can be found through search by name from the server.)
+      input :library_name, title: 'Library name'
+
+      run do
+        fhir_search(:library, params: { name: library_name })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by name returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.name.downcase.include?(library_name.downcase), "Requested resource
+        with name #{library_name}, received resource with name #{resource.entry[0].resource.name}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the library
+      matching a title'
+      id 'read-and-search-library-07'
+      description %(This test verifies a Library resource can be found through search by title from the server.)
+      input :library_title, title: 'Library title'
+
+      run do
+        fhir_search(:library, params: { title: library_title })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by title returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.title.downcase.include?(library_title.downcase), "Requested resource
+        with title #{library_title}, received resource with title #{resource.entry[0].resource.title}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the library
+      matching a status'
+      id 'read-and-search-library-08'
+      description %(This test verifies a Library resource can be found through search by status from the server.)
+      input :library_status, title: 'Library status'
+
+      run do
+        fhir_search(:library, params: { status: library_status })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by status returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.status == library_status, "Requested resource with status
+         #{library_status}, received resource with status #{resource.entry[0].resource.status}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the library
+      matching a description'
+      id 'read-and-search-library-09'
+      description %(This test verifies a Library resource can be found through search by description from the
+      server.)
+      input :library_description, title: 'Library description'
+
+      run do
+        fhir_search(:library, params: { description: library_description })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by description returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.description.downcase.include?(library_description.downcase),
+               "Requested resource with description #{library_description}, received resource with description
+        #{resource.entry[0].resource.description}"
+      end
+    end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/measure_repository_service_test_kit/library_group.rb
+++ b/lib/measure_repository_service_test_kit/library_group.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require 'json'
-require_relative '../utils/package_utils'
+require_relative '../utils/general_utils'
 
 module MeasureRepositoryServiceTestKit
   # tests for read by ID and search for Library service
   # rubocop:disable Metrics/ClassLength
   class LibraryGroup < Inferno::TestGroup
-    include PackageUtils
+    include GeneralUtils
 
     title 'Library Read by Id and Search'
     description 'Ensure measure repository service can retrieve Library resources by the server-defined id and search'

--- a/lib/measure_repository_service_test_kit/library_group.rb
+++ b/lib/measure_repository_service_test_kit/library_group.rb
@@ -134,8 +134,8 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         assert(!resource.entry[0].nil?, 'Search by name returned an empty FHIR searchset bundle')
-        assert resource.entry[0].resource.name.downcase.include?(library_name.downcase), "Requested resource
-        with name #{library_name}, received resource with name #{resource.entry[0].resource.name}"
+        assert(/^#{library_name}/.match(resource.entry[0].resource.name), "Requested resource
+        with name #{library_name}, received resource with name #{resource.entry[0].resource.name}")
       end
     end
 
@@ -153,8 +153,8 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         assert(!resource.entry[0].nil?, 'Search by title returned an empty FHIR searchset bundle')
-        assert resource.entry[0].resource.title.downcase.include?(library_title.downcase), "Requested resource
-        with title #{library_title}, received resource with title #{resource.entry[0].resource.title}"
+        assert(/^#{library_title}/.match(resource.entry[0].resource.title), "Requested resource
+        with title #{library_title}, received resource with title #{resource.entry[0].resource.title}")
       end
     end
 
@@ -192,9 +192,9 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         assert(!resource.entry[0].nil?, 'Search by description returned an empty FHIR searchset bundle')
-        assert resource.entry[0].resource.description.downcase.include?(library_description.downcase),
-               "Requested resource with description #{library_description}, received resource with description
-        #{resource.entry[0].resource.description}"
+        assert(/^#{library_description}/.match(resource.entry[0].resource.description), "Requested resource
+        with description #{library_description}, received resource with description
+        #{resource.entry[0].resource.description}")
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/lib/measure_repository_service_test_kit/library_package.rb
+++ b/lib/measure_repository_service_test_kit/library_package.rb
@@ -2,12 +2,14 @@
 
 require 'json'
 require_relative '../utils/package_utils'
+require_relative '../utils/general_utils'
 
 module MeasureRepositoryServiceTestKit
   # tests for Library $package service
   # rubocop:disable Metrics/ClassLength
   class LibraryPackage < Inferno::TestGroup
     include PackageUtils
+    include GeneralUtils
 
     title 'Library $package'
     description 'Ensure measure repository service can execute the $package operation to the Library endpoint'

--- a/lib/measure_repository_service_test_kit/measure_group.rb
+++ b/lib/measure_repository_service_test_kit/measure_group.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require 'json'
-require_relative '../utils/package_utils'
+require_relative '../utils/general_utils'
 
 module MeasureRepositoryServiceTestKit
   # tests for read by ID and search for Measure service
   # rubocop:disable Metrics/ClassLength
   class MeasureGroup < Inferno::TestGroup
-    include PackageUtils
+    include GeneralUtils
 
     title 'Measure Read by Id and Search'
     description 'Ensure measure repository service can retrieve Measure resources by the server-defined id and search'

--- a/lib/measure_repository_service_test_kit/measure_group.rb
+++ b/lib/measure_repository_service_test_kit/measure_group.rb
@@ -17,6 +17,13 @@ module MeasureRepositoryServiceTestKit
       url :url
     end
 
+    status_type_options = { list_options: [{ label: 'Active', value: 'active' },
+                                           { label: 'Draft', value: 'draft' },
+                                           { label: 'Retired', value: 'retired' },
+                                           { label: 'Unknown', value: 'unknown' }] }
+    status_type_args = { type: 'radio', optional: false, default: 'active', options: status_type_options,
+                         title: 'Status' }
+
     INVALID_ID = 'INVALID_ID'
 
     test do
@@ -157,7 +164,7 @@ module MeasureRepositoryServiceTestKit
       matching a status'
       id 'read-and-search-measure-08'
       description %(This test verifies a Measure resource can be found through search by status from the server.)
-      input :measure_status, title: 'Measure status'
+      input :measure_status, **status_type_args
 
       run do
         fhir_search(:measure, params: { status: measure_status })

--- a/lib/measure_repository_service_test_kit/measure_group.rb
+++ b/lib/measure_repository_service_test_kit/measure_group.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'json'
+require_relative '../utils/package_utils'
 
 module MeasureRepositoryServiceTestKit
   # tests for read by ID and search for Measure service
+  # rubocop:disable Metrics/ClassLength
   class MeasureGroup < Inferno::TestGroup
+    include PackageUtils
+
     title 'Measure Read by Id and Search'
     description 'Ensure measure repository service can retrieve Measure resources by the server-defined id and search'
     id 'measure_group'
@@ -17,7 +21,7 @@ module MeasureRepositoryServiceTestKit
 
     test do
       title 'Server returns 200 response status and correct Measure resource from the read interaction'
-      id 'read-by-id-measure-01'
+      id 'read-and-search-measure-01'
       description %(This test verifies that the Measure resource can be read from the server.)
       input :measure_id, title: 'Measure id'
       output :measure_id
@@ -35,7 +39,7 @@ module MeasureRepositoryServiceTestKit
 
     test do
       title 'Server returns 404 response status when the resource is not available on the server'
-      id 'read-by-id-measure-02'
+      id 'read-and-search-measure-02'
       description %(This test verifies that the server appropriately returns 404 response status
                   for a resource whose id cannot be found in the server's database.)
 
@@ -48,5 +52,144 @@ module MeasureRepositoryServiceTestKit
         assert(resource.issue[0].severity == 'error')
       end
     end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the measure
+      matching a url'
+      id 'read-and-search-measure-03'
+      description %(This test verifies that a Measure resource can be found through search by url from the server.)
+      input :measure_url, title: 'Measure url'
+
+      run do
+        fhir_search(:measure, params: { url: measure_url })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by url returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.url == measure_url,
+               "Requested resource with url #{measure_url}, received resource with
+                url #{resource.entry[0].resource.url}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the measure
+      matching a version'
+      id 'read-and-search-measure-04'
+      description %(This test verifies that a Measure resource can be found through search by version
+      from the server.)
+      input :measure_version, title: 'Measure version'
+
+      run do
+        fhir_search(:measure, params: { version: measure_version })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by version returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.version == measure_version, "Requested resource with version
+         #{measure_version}, received resource with version #{resource.entry[0].resource.version}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the measure
+      matching an identifier'
+      id 'read-and-search-measure-05'
+      description %(This test verifies that a Measure resource can be found through search by identifier.)
+      input :measure_identifier, title: 'Measure Identifier'
+
+      run do
+        fhir_search(:measure, params: { identifier: measure_identifier })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by identifier returned an empty FHIR searchset bundle')
+        assert resource_has_matching_identifier?(resource.entry[0].resource, measure_identifier),
+               "Requested resource with identifier #{measure_identifier}, received resource with identifier
+        #{resource.entry[0].resource.identifier}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct verisons of the measure
+      matching a name'
+      id 'read-and-search-measure-06'
+      description %(This test verifies that a Measure resource can be found through search by name from the
+      server.)
+      input :measure_name, title: 'Measure name'
+
+      run do
+        fhir_search(:measure, params: { name: measure_name })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by name returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.name.downcase.include?(measure_name.downcase), "Requested resource
+        with name #{measure_name}, received resource with name #{resource.entry[0].resource.name}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the measure
+      matching a title'
+      id 'read-and-search-measure-07'
+      description %(This test verifies a Measure resource can be found through search by title from the server.)
+      input :measure_title, title: 'Measure title'
+
+      run do
+        fhir_search(:measure, params: { title: measure_title })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by title returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.title.downcase.include?(measure_title.downcase), "Requested resource
+        with title #{measure_title}, received resource with title #{resource.entry[0].resource.title}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the measure
+      matching a status'
+      id 'read-and-search-measure-08'
+      description %(This test verifies a Measure resource can be found through search by status from the server.)
+      input :measure_status, title: 'Measure status'
+
+      run do
+        fhir_search(:measure, params: { status: measure_status })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by status returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.status == measure_status, "Requested resource with status
+         #{measure_status}, received resource with status #{resource.entry[0].resource.status}"
+      end
+    end
+
+    test do
+      title 'Server returns 200 response status and bundle that contains all the correct versions of the measure
+      matching a description'
+      id 'read-and-search-measure-09'
+      description %(This test verifies a Measure resource can be found through search by description.)
+      input :measure_description, title: 'Measure description'
+
+      run do
+        fhir_search(:measure, params: { description: measure_description })
+
+        assert_response_status(200)
+        assert_resource_type(:bundle)
+        assert_valid_json(response[:body])
+        assert(!resource.entry[0].nil?, 'Search by description returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.description.downcase.include?(measure_description.downcase),
+               "Requested resource with description #{measure_description}, received resource with description
+        #{resource.entry[0].resource.description}"
+      end
+    end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/measure_repository_service_test_kit/measure_group.rb
+++ b/lib/measure_repository_service_test_kit/measure_group.rb
@@ -135,8 +135,8 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         assert(!resource.entry[0].nil?, 'Search by name returned an empty FHIR searchset bundle')
-        assert resource.entry[0].resource.name.downcase.include?(measure_name.downcase), "Requested resource
-        with name #{measure_name}, received resource with name #{resource.entry[0].resource.name}"
+        assert(/^#{measure_name}/.match(resource.entry[0].resource.name), "Requested resource
+        with name #{measure_name}, received resource with name #{resource.entry[0].resource.name}")
       end
     end
 
@@ -154,8 +154,8 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         assert(!resource.entry[0].nil?, 'Search by title returned an empty FHIR searchset bundle')
-        assert resource.entry[0].resource.title.downcase.include?(measure_title.downcase), "Requested resource
-        with title #{measure_title}, received resource with title #{resource.entry[0].resource.title}"
+        assert(/^#{measure_title}/.match(resource.entry[0].resource.title), "Requested resource
+        with title #{measure_title}, received resource with title #{resource.entry[0].resource.title}")
       end
     end
 
@@ -192,9 +192,9 @@ module MeasureRepositoryServiceTestKit
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         assert(!resource.entry[0].nil?, 'Search by description returned an empty FHIR searchset bundle')
-        assert resource.entry[0].resource.description.downcase.include?(measure_description.downcase),
-               "Requested resource with description #{measure_description}, received resource with description
-        #{resource.entry[0].resource.description}"
+        assert(/^#{measure_description}/.match(resource.entry[0].resource.description), "Requested resource
+        with description #{measure_description}, received resource with description
+        #{resource.entry[0].resource.description}")
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -2,12 +2,14 @@
 
 require 'json'
 require_relative '../utils/package_utils'
+require_relative '../utils/general_utils'
 
 module MeasureRepositoryServiceTestKit
   # tests for Measure $package service
   # rubocop:disable Metrics/ClassLength
   class MeasurePackage < Inferno::TestGroup
     include PackageUtils
+    include GeneralUtils
 
     title 'Measure $package'
     description 'Ensure measure repository service can execute the $package operation to the Measure endpoint'

--- a/lib/utils/general_utils.rb
+++ b/lib/utils/general_utils.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 module MeasureRepositoryServiceTestKit
   # Utility functions in support of all test groups
   module GeneralUtils

--- a/lib/utils/general_utils.rb
+++ b/lib/utils/general_utils.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module MeasureRepositoryServiceTestKit
+  # Utility functions in support of all test groups
+  module GeneralUtils
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def resource_has_matching_identifier?(resource, identifier)
+      sys, value = split_identifier(identifier)
+      resource.identifier.any? do |iden|
+        does_match = true
+        does_match &&= iden.value == value if !iden.value.nil? && value
+        does_match &&= iden.system == sys if !iden.system.nil? && sys
+        does_match
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
+    # rubocop:disable Metrics/MethodLength
+    def split_identifier(identifier)
+      iden_split = identifier.split('|')
+      value = sys = nil
+      if iden_split.length == 1
+        value = iden_split[0]
+      elsif iden_split[0] == ''
+        value = iden_split[1]
+      elsif iden_split[1] == ''
+        sys = iden_split[0]
+      else
+        sys = iden_split[0]
+        value = iden_split[1]
+      end
+      [sys, value]
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/lib/utils/general_utils.rb
+++ b/lib/utils/general_utils.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
 
 module MeasureRepositoryServiceTestKit
   # Utility functions in support of all test groups

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -72,35 +72,5 @@ module MeasureRepositoryServiceTestKit
       entry.resource
     end
     # rubocop:enable Metrics/MethodLength
-
-    # rubocop:disable Metrics/CyclomaticComplexity
-    def resource_has_matching_identifier?(resource, identifier)
-      sys, value = split_identifier(identifier)
-      resource.identifier.any? do |iden|
-        does_match = true
-        does_match &&= iden.value == value if !iden.value.nil? && value
-        does_match &&= iden.system == sys if !iden.system.nil? && sys
-        does_match
-      end
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
-
-    # rubocop:disable Metrics/MethodLength
-    def split_identifier(identifier)
-      iden_split = identifier.split('|')
-      value = sys = nil
-      if iden_split.length == 1
-        value = iden_split[0]
-      elsif iden_split[0] == ''
-        value = iden_split[1]
-      elsif iden_split[1] == ''
-        sys = iden_split[0]
-      else
-        sys = iden_split[0]
-        value = iden_split[1]
-      end
-      [sys, value]
-    end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/spec/measure_repository_service_test_kit/library_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_group_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 
-  describe 'Server successfully retrieves specified resource by its id' do
+  describe 'Server successfully retrieves Library by its id' do
     let(:test) { group.tests.first }
     let(:library_id) { 'library_id' }
 
@@ -89,7 +89,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its url' do
+  describe 'Server successfully searches and retrieves Library by its url' do
     let(:test) { group.tests[2] }
     let(:library_url) { 'library_url' }
 
@@ -142,7 +142,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its version' do
+  describe 'Server successfully searches and retrieves Library by its version' do
     let(:test) { group.tests[3] }
     let(:library_version) { 'library_version' }
 
@@ -195,7 +195,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its identifier' do
+  describe 'Server successfully searches and retrieves Library by its identifier' do
     let(:test) { group.tests[4] }
     let(:library_identifier) { 'identifier_system|identifier_value' }
     let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
@@ -262,7 +262,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its name' do
+  describe 'Server successfully searches and retrieves Library by its name' do
     let(:test) { group.tests[5] }
     let(:library_name) { 'library_name' }
 
@@ -315,7 +315,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its title' do
+  describe 'Server successfully searches and retrieves Library by its title' do
     let(:test) { group.tests[6] }
     let(:library_title) { 'library_title' }
 
@@ -368,7 +368,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its status' do
+  describe 'Server successfully searches and retrieves Library by its status' do
     let(:test) { group.tests[7] }
     let(:library_status) { 'library_status' }
 
@@ -398,7 +398,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
 
     it 'fails if the libraries in the returned FHIR searchset bundle do not match the
       requested status' do
-      library = FHIR::Library.new(status: 'INVALID_STATUS')
+      library = FHIR::Library.new(status: 'active')
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :get,
@@ -421,7 +421,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its description' do
+  describe 'Server successfully searches and retrieves Library by its description' do
     let(:test) { group.tests[8] }
     let(:library_description) { 'library_description' }
 

--- a/spec/measure_repository_service_test_kit/library_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_group_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      library =  FHIR::Library.new(url: 'INVALID_URL')
+      library = FHIR::Library.new(url: library_url)
       stub_request(
         :get,
         "#{url}/Library?url=#{library_url}"
@@ -184,7 +184,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      library =  FHIR::Library.new(version: 'INVALID_VERSION')
+      library =  FHIR::Library.new(version: library_version)
       stub_request(
         :get,
         "#{url}/Library?version=#{library_version}"
@@ -251,7 +251,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      library =  FHIR::Library.new(identifier: 'INVALID_IDENTIFIER')
+      library =  FHIR::Library.new(identifier: library_identifier)
       stub_request(
         :get,
         "#{url}/Library?identifier=#{library_identifier}"
@@ -304,7 +304,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      library =  FHIR::Library.new(name: 'INVALID_NAME')
+      library =  FHIR::Library.new(name: library_name)
       stub_request(
         :get,
         "#{url}/Library?name=#{library_name}"
@@ -357,7 +357,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      library =  FHIR::Library.new(title: 'INVALID_TITLE')
+      library =  FHIR::Library.new(title: library_title)
       stub_request(
         :get,
         "#{url}/Library?title=#{library_title}"
@@ -410,7 +410,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      library =  FHIR::Library.new(status: 'INVALID_STATUS')
+      library =  FHIR::Library.new(status: library_status)
       stub_request(
         :get,
         "#{url}/Library?status=#{library_status}"
@@ -463,7 +463,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      library =  FHIR::Library.new(description: 'INVALID_DESCRIPTION')
+      library =  FHIR::Library.new(description: library_description)
       stub_request(
         :get,
         "#{url}/Library?description=#{library_description}"

--- a/spec/measure_repository_service_test_kit/library_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_group_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
 
   describe 'Server successfully searches and retrieves Library by its status' do
     let(:test) { group.tests[7] }
-    let(:library_status) { 'library_status' }
+    let(:library_status) { 'draft' }
 
     it 'passes if the libraries in the returned FHIR searchset bundle match the requested status' do
       library = FHIR::Library.new(status: library_status)

--- a/spec/measure_repository_service_test_kit/library_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_group_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
   end
 
   describe 'Server returns 404 for id that does not exist on server database' do
-    let(:test) { group.tests.last }
+    let(:test) { group.tests[1] }
     let(:library_id) { 'INVALID_ID' }
 
     it 'passes if request returns 404 with OperationOutcome' do
@@ -85,6 +85,391 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
         "#{url}/Library/#{library_id}"
       ).to_return(status: 404, body: resource.to_json)
       result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its url' do
+    let(:test) { group.tests[2] }
+    let(:library_url) { 'library_url' }
+
+    it 'passes if the libraries in the returned FHIR searchset bundle match the requested url' do
+      library = FHIR::Library.new(url: library_url)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?url=#{library_url}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      library =  FHIR::Library.new(url: library_url)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?url=#{library_url}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the libraries in the returned FHIR searchset bundle do not match the
+      requested url' do
+      library = FHIR::Library.new(url: 'INVALID_URL')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?url=#{library_url}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      library =  FHIR::Library.new(url: 'INVALID_URL')
+      stub_request(
+        :get,
+        "#{url}/Library?url=#{library_url}"
+      ).to_return(status: 200, body: library.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its version' do
+    let(:test) { group.tests[3] }
+    let(:library_version) { 'library_version' }
+
+    it 'passes if the libraries in the returned FHIR searchset bundle match the requested version' do
+      library = FHIR::Library.new(version: library_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?version=#{library_version}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_version:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      library =  FHIR::Library.new(version: library_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?version=#{library_version}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the libraries in the returned FHIR searchset bundle do not match the
+      requested version' do
+      library = FHIR::Library.new(version: 'INVALID_VERSION')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?version=#{library_version}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      library =  FHIR::Library.new(version: 'INVALID_VERSION')
+      stub_request(
+        :get,
+        "#{url}/Library?version=#{library_version}"
+      ).to_return(status: 200, body: library.to_json)
+
+      result = run(test, url:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its identifier' do
+    let(:test) { group.tests[4] }
+    let(:library_identifier) { 'identifier_system|identifier_value' }
+    let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
+
+    it 'passes if the libraries in the returned FHIR searchset bundle match the requested identifier' do
+      library = FHIR::Library.new(identifier: expected_identifier)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?identifier=#{library_identifier}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      library =  FHIR::Library.new(identifier: library_identifier)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?identifier=#{library_identifier}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the libraries in the returned FHIR searchset bundle do not match the
+      requested identifier system' do
+      library = FHIR::Library.new(identifier: { system: 'invalid_system', value: 'identifier_value' })
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?identifier=#{library_identifier}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the libraries in the returned FHIR searchset bundle do not match the
+      requested identifier value' do
+      library = FHIR::Library.new(identifier: { system: 'identifier_system', value: 'invalid_value' })
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?identifier=#{library_identifier}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      library =  FHIR::Library.new(identifier: 'INVALID_IDENTIFIER')
+      stub_request(
+        :get,
+        "#{url}/Library?identifier=#{library_identifier}"
+      ).to_return(status: 200, body: library.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its name' do
+    let(:test) { group.tests[5] }
+    let(:library_name) { 'library_name' }
+
+    it 'passes if the libraries in the returned FHIR searchset bundle match the requested name' do
+      library = FHIR::Library.new(name: library_name)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?name=#{library_name}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_name:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      library =  FHIR::Library.new(name: library_name)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?name=#{library_name}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_name:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the libraries in the returned FHIR searchset bundle do not match the
+      requested name' do
+      library = FHIR::Library.new(name: 'INVALID_NAME')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?name=#{library_name}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_name:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      library =  FHIR::Library.new(name: 'INVALID_NAME')
+      stub_request(
+        :get,
+        "#{url}/Library?name=#{library_name}"
+      ).to_return(status: 200, body: library.to_json)
+
+      result = run(test, url:, library_name:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its title' do
+    let(:test) { group.tests[6] }
+    let(:library_title) { 'library_title' }
+
+    it 'passes if the libraries in the returned FHIR searchset bundle match the requested title' do
+      library = FHIR::Library.new(title: library_title)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?title=#{library_title}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_title:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      library =  FHIR::Library.new(title: library_title)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?title=#{library_title}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_title:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the libraries in the returned FHIR searchset bundle do not match the
+      requested title' do
+      library = FHIR::Library.new(title: 'INVALID_TITLE')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?title=#{library_title}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_title:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      library =  FHIR::Library.new(title: 'INVALID_TITLE')
+      stub_request(
+        :get,
+        "#{url}/Library?title=#{library_title}"
+      ).to_return(status: 200, body: library.to_json)
+
+      result = run(test, url:, library_title:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its status' do
+    let(:test) { group.tests[7] }
+    let(:library_status) { 'library_status' }
+
+    it 'passes if the libraries in the returned FHIR searchset bundle match the requested status' do
+      library = FHIR::Library.new(status: library_status)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?status=#{library_status}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_status:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      library =  FHIR::Library.new(status: library_status)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?status=#{library_status}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_status:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the libraries in the returned FHIR searchset bundle do not match the
+      requested status' do
+      library = FHIR::Library.new(status: 'INVALID_STATUS')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?status=#{library_status}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_status:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      library =  FHIR::Library.new(status: 'INVALID_STATUS')
+      stub_request(
+        :get,
+        "#{url}/Library?status=#{library_status}"
+      ).to_return(status: 200, body: library.to_json)
+
+      result = run(test, url:, library_status:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its description' do
+    let(:test) { group.tests[8] }
+    let(:library_description) { 'library_description' }
+
+    it 'passes if the libraries in the returned FHIR searchset bundle match the requested description' do
+      library = FHIR::Library.new(description: library_description)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?description=#{library_description}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_description:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      library =  FHIR::Library.new(description: library_description)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?description=#{library_description}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, library_description:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the libraries in the returned FHIR searchset bundle do not match the
+      requested description' do
+      library = FHIR::Library.new(description: 'INVALID_DESCRIPTION')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
+      stub_request(
+        :get,
+        "#{url}/Library?description=#{library_description}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, library_description:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      library =  FHIR::Library.new(description: 'INVALID_DESCRIPTION')
+      stub_request(
+        :get,
+        "#{url}/Library?description=#{library_description}"
+      ).to_return(status: 200, body: library.to_json)
+
+      result = run(test, url:, library_description:)
       expect(result.result).to eq('fail')
     end
   end

--- a/spec/measure_repository_service_test_kit/measure_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_group_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      measure =  FHIR::Measure.new(url: 'INVALID_URL')
+      measure =  FHIR::Measure.new(url: measure_url)
       stub_request(
         :get,
         "#{url}/Measure?url=#{measure_url}"
@@ -184,7 +184,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      measure =  FHIR::Measure.new(version: 'INVALID_VERSION')
+      measure =  FHIR::Measure.new(version: measure_version)
       stub_request(
         :get,
         "#{url}/Measure?version=#{measure_version}"
@@ -251,7 +251,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      measure =  FHIR::Measure.new(identifier: 'INVALID_IDENTIFIER')
+      measure =  FHIR::Measure.new(identifier: measure_identifier)
       stub_request(
         :get,
         "#{url}/Measure?identifier=#{measure_identifier}"
@@ -304,7 +304,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      measure =  FHIR::Measure.new(name: 'INVALID_NAME')
+      measure =  FHIR::Measure.new(name: measure_name)
       stub_request(
         :get,
         "#{url}/Measure?name=#{measure_name}"
@@ -357,7 +357,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      measure =  FHIR::Measure.new(title: 'INVALID_TITLE')
+      measure =  FHIR::Measure.new(title: measure_title)
       stub_request(
         :get,
         "#{url}/Measure?title=#{measure_title}"
@@ -410,7 +410,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      measure =  FHIR::Measure.new(status: 'INVALID_STATUS')
+      measure =  FHIR::Measure.new(status: measure_status)
       stub_request(
         :get,
         "#{url}/Measure?status=#{measure_status}"
@@ -463,7 +463,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      measure =  FHIR::Measure.new(description: 'INVALID_DESCRIPTION')
+      measure =  FHIR::Measure.new(description: measure_description)
       stub_request(
         :get,
         "#{url}/Measure?description=#{measure_description}"

--- a/spec/measure_repository_service_test_kit/measure_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_group_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
 
   describe 'Server successfully searches and retrieves Measure by its status' do
     let(:test) { group.tests[7] }
-    let(:measure_status) { 'measure_status' }
+    let(:measure_status) { 'draft' }
 
     it 'passes if the measures in the returned FHIR searchset bundle match the requested status' do
       measure = FHIR::Measure.new(status: measure_status)

--- a/spec/measure_repository_service_test_kit/measure_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_group_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
   end
 
   describe 'Server returns 404 for id that does not exist on server database' do
-    let(:test) { group.tests.last }
+    let(:test) { group.tests[1] }
     let(:measure_id) { 'INVALID_ID' }
 
     it 'passes if request returns 404 with OperationOutcome' do
@@ -85,6 +85,391 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
         "#{url}/Measure/#{measure_id}"
       ).to_return(status: 404, body: resource.to_json)
       result = run(test, url:, measure_id:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its url' do
+    let(:test) { group.tests[2] }
+    let(:measure_url) { 'measure_url' }
+
+    it 'passes if the measures in the returned FHIR searchset bundle match the requested url' do
+      measure = FHIR::Measure.new(url: measure_url)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?url=#{measure_url}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      measure =  FHIR::Measure.new(url: measure_url)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?url=#{measure_url}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, measure_url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the measures in the returned FHIR searchset bundle do not match the
+      requested url' do
+      measure = FHIR::Measure.new(url: 'INVALID_URL')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?url=#{measure_url}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      measure =  FHIR::Measure.new(url: 'INVALID_URL')
+      stub_request(
+        :get,
+        "#{url}/Measure?url=#{measure_url}"
+      ).to_return(status: 200, body: measure.to_json)
+
+      result = run(test, url:, measure_url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its version' do
+    let(:test) { group.tests[3] }
+    let(:measure_version) { 'measure_version' }
+
+    it 'passes if the measures in the returned FHIR searchset bundle match the requested version' do
+      measure = FHIR::Measure.new(version: measure_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?version=#{measure_version}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_version:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      measure =  FHIR::Measure.new(version: measure_version)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?version=#{measure_version}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, measure_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the measures in the returned FHIR searchset bundle do not match the
+      requested version' do
+      measure = FHIR::Measure.new(version: 'INVALID_VERSION')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?version=#{measure_version}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      measure =  FHIR::Measure.new(version: 'INVALID_VERSION')
+      stub_request(
+        :get,
+        "#{url}/Measure?version=#{measure_version}"
+      ).to_return(status: 200, body: measure.to_json)
+
+      result = run(test, url:, measure_version:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its identifier' do
+    let(:test) { group.tests[4] }
+    let(:measure_identifier) { 'identifier_system|identifier_value' }
+    let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
+
+    it 'passes if the measures in the returned FHIR searchset bundle match the requested identifier' do
+      measure = FHIR::Measure.new(identifier: expected_identifier)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?identifier=#{measure_identifier}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_identifier:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      measure =  FHIR::Measure.new(identifier: measure_identifier)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?identifier=#{measure_identifier}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, measure_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the measures in the returned FHIR searchset bundle do not match the
+      requested identifier system' do
+      measure = FHIR::Measure.new(identifier: { system: 'invalid_system', value: 'identifier_value' })
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?identifier=#{measure_identifier}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the measures in the returned FHIR searchset bundle do not match the
+      requested identifier value' do
+      measure = FHIR::Measure.new(identifier: { system: 'identifier_system', value: 'invalid_value' })
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?identifier=#{measure_identifier}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      measure =  FHIR::Measure.new(identifier: 'INVALID_IDENTIFIER')
+      stub_request(
+        :get,
+        "#{url}/Measure?identifier=#{measure_identifier}"
+      ).to_return(status: 200, body: measure.to_json)
+
+      result = run(test, url:, measure_identifier:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its name' do
+    let(:test) { group.tests[5] }
+    let(:measure_name) { 'measure_name' }
+
+    it 'passes if the measures in the returned FHIR searchset bundle match the requested name' do
+      measure = FHIR::Measure.new(name: measure_name)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?name=#{measure_name}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_name:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      measure =  FHIR::Measure.new(name: measure_name)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?name=#{measure_name}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, measure_name:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the measures in the returned FHIR searchset bundle do not match the
+      requested name' do
+      measure = FHIR::Measure.new(name: 'INVALID_NAME')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?name=#{measure_name}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_name:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      measure =  FHIR::Measure.new(name: 'INVALID_NAME')
+      stub_request(
+        :get,
+        "#{url}/Measure?name=#{measure_name}"
+      ).to_return(status: 200, body: measure.to_json)
+
+      result = run(test, url:, measure_name:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its title' do
+    let(:test) { group.tests[6] }
+    let(:measure_title) { 'measure_title' }
+
+    it 'passes if the measures in the returned FHIR searchset bundle match the requested title' do
+      measure = FHIR::Measure.new(title: measure_title)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?title=#{measure_title}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_title:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      measure =  FHIR::Measure.new(title: measure_title)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?title=#{measure_title}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, measure_title:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the measures in the returned FHIR searchset bundle do not match the
+      requested title' do
+      measure = FHIR::Measure.new(title: 'INVALID_TITLE')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?title=#{measure_title}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_title:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      measure =  FHIR::Measure.new(title: 'INVALID_TITLE')
+      stub_request(
+        :get,
+        "#{url}/Measure?title=#{measure_title}"
+      ).to_return(status: 200, body: measure.to_json)
+
+      result = run(test, url:, measure_title:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its status' do
+    let(:test) { group.tests[7] }
+    let(:measure_status) { 'measure_status' }
+
+    it 'passes if the measures in the returned FHIR searchset bundle match the requested status' do
+      measure = FHIR::Measure.new(status: measure_status)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?status=#{measure_status}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_status:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      measure =  FHIR::Measure.new(status: measure_status)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?status=#{measure_status}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, measure_status:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the measures in the returned FHIR searchset bundle do not match the
+      requested status' do
+      measure = FHIR::Measure.new(status: 'INVALID_STATUS')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?status=#{measure_status}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_status:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      measure =  FHIR::Measure.new(status: 'INVALID_STATUS')
+      stub_request(
+        :get,
+        "#{url}/Measure?status=#{measure_status}"
+      ).to_return(status: 200, body: measure.to_json)
+
+      result = run(test, url:, measure_status:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully searches and retrieves specified resource by its description' do
+    let(:test) { group.tests[8] }
+    let(:measure_description) { 'measure_description' }
+
+    it 'passes if the measures in the returned FHIR searchset bundle match the requested description' do
+      measure = FHIR::Measure.new(description: measure_description)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?description=#{measure_description}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_description:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if search does not return 200' do
+      measure =  FHIR::Measure.new(description: measure_description)
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?description=#{measure_description}"
+      ).to_return(status: 400, body: bundle.to_json)
+
+      result = run(test, url:, measure_description:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the measures in the returned FHIR searchset bundle do not match the
+      requested description' do
+      measure = FHIR::Measure.new(description: 'INVALID_DESCRIPTION')
+      bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
+      stub_request(
+        :get,
+        "#{url}/Measure?description=#{measure_description}"
+      ).to_return(status: 200, body: bundle.to_json)
+
+      result = run(test, url:, measure_description:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if the search request does not return a FHIR searchset bundle' do
+      measure =  FHIR::Measure.new(description: 'INVALID_DESCRIPTION')
+      stub_request(
+        :get,
+        "#{url}/Measure?description=#{measure_description}"
+      ).to_return(status: 200, body: measure.to_json)
+
+      result = run(test, url:, measure_description:)
       expect(result.result).to eq('fail')
     end
   end

--- a/spec/measure_repository_service_test_kit/measure_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_group_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 
-  describe 'Server successfully retrieves specified resource by its id' do
+  describe 'Server successfully retrieves Measure by its id' do
     let(:test) { group.tests.first }
     let(:measure_id) { 'measure_id' }
 
@@ -89,7 +89,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its url' do
+  describe 'Server successfully searches and retrieves Measure by its url' do
     let(:test) { group.tests[2] }
     let(:measure_url) { 'measure_url' }
 
@@ -142,7 +142,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its version' do
+  describe 'Server successfully searches and retrieves Measure by its version' do
     let(:test) { group.tests[3] }
     let(:measure_version) { 'measure_version' }
 
@@ -195,7 +195,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its identifier' do
+  describe 'Server successfully searches and retrieves Measure by its identifier' do
     let(:test) { group.tests[4] }
     let(:measure_identifier) { 'identifier_system|identifier_value' }
     let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
@@ -262,7 +262,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its name' do
+  describe 'Server successfully searches and retrieves Measure by its name' do
     let(:test) { group.tests[5] }
     let(:measure_name) { 'measure_name' }
 
@@ -315,7 +315,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its title' do
+  describe 'Server successfully searches and retrieves Measure by its title' do
     let(:test) { group.tests[6] }
     let(:measure_title) { 'measure_title' }
 
@@ -368,7 +368,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its status' do
+  describe 'Server successfully searches and retrieves Measure by its status' do
     let(:test) { group.tests[7] }
     let(:measure_status) { 'measure_status' }
 
@@ -398,7 +398,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
 
     it 'fails if the measures in the returned FHIR searchset bundle do not match the
       requested status' do
-      measure = FHIR::Measure.new(status: 'INVALID_STATUS')
+      measure = FHIR::Measure.new(status: 'active')
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :get,
@@ -421,7 +421,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
     end
   end
 
-  describe 'Server successfully searches and retrieves specified resource by its description' do
+  describe 'Server successfully searches and retrieves Measure by its description' do
     let(:test) { group.tests[8] }
     let(:measure_description) { 'measure_description' }
 


### PR DESCRIPTION
# Summary
Added tests for search functionality for the SHALLs [(10.2.1.5.2.1 core searches)](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#core-searches) in the Library and Measure Services in the measure-repository-service. The corresponding search functionality PR for the measure-repository-service is [here](https://github.com/projecttacoma/measure-repository-service/pull/3) for reference.

## New behavior
- New tests in the existing Library group and Measure group test groups that test each of the SHALL search capabilities (search by url, version, identifier, name, title, status, description). 
- Corresponding rspec tests for added tests. 

## Code changes
- `library_group.rb` - 7 additional tests for all the SHALL search capabilities. 
- `measure_group.rb` - 7 additional tests for all the SHALL search capabilities.
- `measure_group_spec.rb` - corresponding rspec tests.
- `library_group_spec.rb` - corresponding rspec tests. 

# Testing guidance
- `rubocop` and `rspec`
- Look at instructions in [this previous PR](https://github.com/projecttacoma/measure-repository-service-test-kit/pull/6) for running the test kit and the measure repository service. You can populate the test kit inputs with whatever you want but here is an example for EXM130 if you want all of the tests to pass:

Measure Search:
![image](https://user-images.githubusercontent.com/30158156/215534594-073d85a8-0f65-46fd-91c0-f848a06a8be7.png)

Library Search:
(Identifier tests still won't pass for EXM130)
![image](https://user-images.githubusercontent.com/30158156/215534921-7d6c82a3-e4e4-40a2-b7a0-088366d04cc9.png)

- Try different search inputs to make sure it passes when expected. Something to note is that for search by name, title, and description, the [spec](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#core-searches) specifies that those return all artifacts matching the (descripiton/title/name), according to string-matching semantics in FHIR. This means that string searches are case-insensitive, accent insensitive, may match just part of the string, and may contain spaces (detailed in the [FHIR search docs](https://build.fhir.org/search.html#ptypes)). 
- There are a ton of code additions but I think it's necessary but let me know if anything is redundant. 
- I would also specifically look for spelling errors and typos since it was a lot of code and a lot of copy pasting.