### PR TITLE
Library data requirements test suite

### DIFF
--- a/lib/measure_repository_service_test_kit.rb
+++ b/lib/measure_repository_service_test_kit.rb
@@ -5,6 +5,7 @@ require_relative 'measure_repository_service_test_kit/library_group'
 require_relative 'measure_repository_service_test_kit/measure_package'
 require_relative 'measure_repository_service_test_kit/library_package'
 require_relative 'measure_repository_service_test_kit/measure_data_requirements'
+require_relative 'measure_repository_service_test_kit/library_data_requirements'
 
 module MeasureRepositoryServiceTestKit
   # Overall test suite
@@ -58,5 +59,6 @@ module MeasureRepositoryServiceTestKit
     group from: :measure_package
     group from: :library_package
     group from: :measure_data_requirements
+    group from: :library_data_requirements
   end
 end

--- a/lib/measure_repository_service_test_kit/library_data_requirements.rb
+++ b/lib/measure_repository_service_test_kit/library_data_requirements.rb
@@ -8,7 +8,7 @@ module MeasureRepositoryServiceTestKit
   # rubocop:disable Metrics/ClassLength
   class LibraryDataRequirements < Inferno::TestGroup
     title 'Library $data-requirements'
-    description 'Ensure measure repository service can execute the $data-requirements operation to the Library endpoint'
+    description 'Ensure measure repository service can run Library/$data-requirements operation'
     id 'library_data_requirements'
     custom_headers = { 'content-type': 'application/fhir+json' }
 
@@ -24,7 +24,7 @@ module MeasureRepositoryServiceTestKit
       description 'returned response has status code 200 and valid JSON FHIR Library with data requirement in body'
       input :library_id, title: 'Library id'
       makes_request :library_data_requirements
-      
+
       run do
         fhir_operation("Library/#{library_id}/$data-requirements", name: :library_data_requirements)
         assert_dr_success
@@ -35,21 +35,28 @@ module MeasureRepositoryServiceTestKit
       include DataRequirementsUtils
       title '200 response and JSON Library body for POST with url in body'
       id 'library-data-requirements-02'
-      description 'returned resopnse has status code 200.'
+      description 'returned response has status code 200.'
       input :library_url, title: 'Library url'
+      input :library_version, optional: true, title: 'Library version'
 
       run do
-        params_hash = {
+        url_params_hash = {
           resourceType: 'Parameters',
           parameter: [
             { name: 'url',
               valueUrl: library_url }
           ]
-        }.freeze
+        }
 
-        params = FHIR::Parameters.new params_hash
+        unless library_version.nil?
+          url_params_hash[:parameter].append({ name: 'version',
+                                               valueString: library_version })
+        end
 
-        fhir_operation('Library/$data-requirements', body: params)
+        url_params_hash = url_params_hash.freeze
+        url_params = FHIR::Parameters.new url_params_hash
+
+        fhir_operation('Library/$data-requirements', body: url_params)
         assert_dr_success
       end
     end
@@ -133,7 +140,7 @@ module MeasureRepositoryServiceTestKit
       id 'library-data-requirements-07'
       description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
       input :library_id, title: 'Library id'
-      
+
       run do
         params_hash = {
           resourceType: 'Parameters',

--- a/lib/measure_repository_service_test_kit/library_data_requirements.rb
+++ b/lib/measure_repository_service_test_kit/library_data_requirements.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
-require_relative '../utils/general_utils'
+require_relative '../utils/data_requirements_utils'
 
 module MeasureRepositoryServiceTestKit
   # tests for Library $package service
@@ -12,12 +12,15 @@ module MeasureRepositoryServiceTestKit
     title 'Library $data-requirements'
     description 'Ensure measure repository service can execute the $data-requirements operation to the Library endpoint'
     id 'library_data_requirements'
+    custom_headers = { 'content-type': 'application/fhir+json' }
 
     fhir_client do
       url :url
+      headers custom_headers
     end
 
     test do
+      include DataRequirementsUtils
       title '200 response and JSON Library body for POST by id in url'
       id 'library-data-requirements-01'
       description 'returned response has status code 200 and valid JSON FHIR Library with data requirement in body'
@@ -25,16 +28,12 @@ module MeasureRepositoryServiceTestKit
       makes_request :library_data_requirements
       run do
         fhir_operation("Library/#{library_id}/$data-requirements", name: :library_data_requirements)
-        assert_response_status(200)
-        assert_resource_type(:library)
-        assert_valid_json(response[:body])
-        assert(resource.dataRequirement, "No data requirement created for library with id: #{library_id}")
-        assert resource.type.coding[0].code == 'module-definition',
-               'Resulting data requirements Library is not type module-definition'
+        assert_dr_success
       end
     end
 
     test do
+      include DataRequirementsUtils
       title '200 response and JSON Library body for POST with url in body'
       id 'library-data-requirements-02'
       description 'returned resopnse has status code 200.'
@@ -52,16 +51,12 @@ module MeasureRepositoryServiceTestKit
         params = FHIR::Parameters.new params_hash
 
         fhir_operation('Library/$data-requirements', body: params)
-        assert_response_status(200)
-        assert_resource_type(:library)
-        assert_valid_json(response[:body])
-        assert(resource.dataRequirement, "No data requirement created for library with url: #{library_url}")
-        assert resource.type.coding[0].code == 'module-definition',
-               'Resulting data requirements Library is not type module-definition'
+        assert_dr_success
       end
     end
 
     test do
+      include DataRequirementsUtils
       title '200 response and JSON Library body for POST with identifier in body'
       id 'library-data-requirements-03'
       description 'returned response has status code 200.'
@@ -79,17 +74,12 @@ module MeasureRepositoryServiceTestKit
         params = FHIR::Parameters.new params_hash
 
         fhir_operation('Library/$data-requirements', body: params)
-        assert_response_status(200)
-        assert_resource_type(:library)
-        assert_valid_json(response[:body])
-        assert(resource.dataRequirement,
-               "No data requirement created for library with identifier: #{library_identifier}")
-        assert resource.type.coding[0].code == 'module-definition',
-               'Resulting data requirements Library is not type module-definition'
+        assert_dr_success
       end
     end
 
     test do
+      include DataRequirementsUtils
       title '200 response and JSON Bundle body for POST parameters url, identifier, and version in body and id in url'
       id 'library-data-requirements-04'
       description 'returned repsonse has status code 200.'
@@ -110,44 +100,36 @@ module MeasureRepositoryServiceTestKit
         params = FHIR::Parameters.new params_hash.freeze
 
         fhir_operation("Library/#{library_id}/$data-requirements", body: params)
-        assert_response_status(200)
-        assert_resource_type(:library)
-        assert_valid_json(response[:body])
-        assert(resource.dataRequirement, "No data requirement created for library with id: #{library_id}")
-        assert resource.type.coding[0].code == 'module-definition',
-               'Resulting data requirements Library is not type module-definition'
+        assert_dr_success
       end
     end
 
     test do
+      include DataRequirementsUtils
       title 'Throws 404 when no Library on server matches id'
       id 'library-data-requirements-05'
       description 'returns 404 status code with OperationOutcome when no Library exists with passed-in id'
 
       run do
         fhir_operation('Library/INVALID_ID/$data-requirements')
-        assert_response_status(404)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        assert_dr_failure(expected_status: 404)
       end
     end
 
     test do
+      include DataRequirementsUtils
       title 'Throws 400 when no id, url, or identifier provided'
       id 'library-data-requirements-06'
       description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
 
       run do
         fhir_operation('Library/$data-requirements')
-        assert_response_status(400)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        assert_dr_failure
       end
     end
 
     test do
+      include DataRequirementsUtils
       title 'Throws 400 when id is included in both the path and as a FHIR parameter'
       id 'library-data-requirements-07'
       description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
@@ -163,10 +145,7 @@ module MeasureRepositoryServiceTestKit
 
         params = FHIR::Parameters.new params_hash
         fhir_operation("Library/#{library_id}/$data-requirements", body: params)
-        assert_response_status(400)
-        assert_valid_json(response[:body])
-        assert(resource.resourceType == 'OperationOutcome')
-        assert(resource.issue[0].severity == 'error')
+        assert_dr_failure
       end
     end
   end

--- a/lib/measure_repository_service_test_kit/library_data_requirements.rb
+++ b/lib/measure_repository_service_test_kit/library_data_requirements.rb
@@ -7,8 +7,6 @@ module MeasureRepositoryServiceTestKit
   # tests for Library $package service
   # rubocop:disable Metrics/ClassLength
   class LibraryDataRequirements < Inferno::TestGroup
-    include GeneralUtils
-
     title 'Library $data-requirements'
     description 'Ensure measure repository service can execute the $data-requirements operation to the Library endpoint'
     id 'library_data_requirements'
@@ -26,6 +24,7 @@ module MeasureRepositoryServiceTestKit
       description 'returned response has status code 200 and valid JSON FHIR Library with data requirement in body'
       input :library_id, title: 'Library id'
       makes_request :library_data_requirements
+      
       run do
         fhir_operation("Library/#{library_id}/$data-requirements", name: :library_data_requirements)
         assert_dr_success
@@ -134,6 +133,7 @@ module MeasureRepositoryServiceTestKit
       id 'library-data-requirements-07'
       description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
       input :library_id, title: 'Library id'
+      
       run do
         params_hash = {
           resourceType: 'Parameters',

--- a/lib/measure_repository_service_test_kit/library_data_requirements.rb
+++ b/lib/measure_repository_service_test_kit/library_data_requirements.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../utils/general_utils'
+
+module MeasureRepositoryServiceTestKit
+  # tests for Library $package service
+  # rubocop:disable Metrics/ClassLength
+  class LibraryDataRequirements < Inferno::TestGroup
+    include GeneralUtils
+
+    title 'Library $data-requirements'
+    description 'Ensure measure repository service can execute the $data-requirements operation to the Library endpoint'
+    id 'library_data_requirements'
+
+    fhir_client do
+      url :url
+    end
+
+    test do
+      title '200 response and JSON Library body for POST by id in url'
+      id 'library-data-requirements-01'
+      description 'returned response has status code 200 and valid JSON FHIR Library with data requirement in body'
+      input :library_id, title: 'Library id'
+      makes_request :library_data_requirements
+      run do
+        fhir_operation("Library/#{library_id}/$data-requirements", name: :library_data_requirements)
+        assert_response_status(200)
+        assert_resource_type(:library)
+        assert_valid_json(response[:body])
+        assert(resource.dataRequirement, "No data requirement created for library with id: #{library_id}")
+        assert resource.type.coding[0].code == 'module-definition',
+               'Resulting data requirements Library is not type module-definition'
+      end
+    end
+
+    test do
+      title '200 response and JSON Library body for POST with url in body'
+      id 'library-data-requirements-02'
+      description 'returned resopnse has status code 200.'
+      input :library_url, title: 'Library url'
+
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'url',
+              valueUrl: library_url }
+          ]
+        }.freeze
+
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation('Library/$data-requirements', body: params)
+        assert_response_status(200)
+        assert_resource_type(:library)
+        assert_valid_json(response[:body])
+        assert(resource.dataRequirement, "No data requirement created for library with url: #{library_url}")
+        assert resource.type.coding[0].code == 'module-definition',
+               'Resulting data requirements Library is not type module-definition'
+      end
+    end
+
+    test do
+      title '200 response and JSON Library body for POST with identifier in body'
+      id 'library-data-requirements-03'
+      description 'returned response has status code 200.'
+      input :library_identifier, title: 'Library Identifier'
+
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'identifier',
+              valueString: library_identifier }
+          ]
+        }.freeze
+
+        params = FHIR::Parameters.new params_hash
+
+        fhir_operation('Library/$data-requirements', body: params)
+        assert_response_status(200)
+        assert_resource_type(:library)
+        assert_valid_json(response[:body])
+        assert(resource.dataRequirement,
+               "No data requirement created for library with identifier: #{library_identifier}")
+        assert resource.type.coding[0].code == 'module-definition',
+               'Resulting data requirements Library is not type module-definition'
+      end
+    end
+
+    test do
+      title '200 response and JSON Bundle body for POST parameters url, identifier, and version in body and id in url'
+      id 'library-data-requirements-04'
+      description 'returned repsonse has status code 200.'
+      input :library_id, title: 'Library id'
+      input :library_url, title: 'Library url'
+      input :library_identifier, title: 'Library identifier'
+      input :library_version, optional: true, title: 'Library version'
+
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'url', valueUrl: library_url },
+            { name: 'identifier', valueString: library_identifier }
+          ]
+        }
+        params_hash[:parameter].append({ name: 'version', valueString: library_version }) unless library_version.nil?
+        params = FHIR::Parameters.new params_hash.freeze
+
+        fhir_operation("Library/#{library_id}/$data-requirements", body: params)
+        assert_response_status(200)
+        assert_resource_type(:library)
+        assert_valid_json(response[:body])
+        assert(resource.dataRequirement, "No data requirement created for library with id: #{library_id}")
+        assert resource.type.coding[0].code == 'module-definition',
+               'Resulting data requirements Library is not type module-definition'
+      end
+    end
+
+    test do
+      title 'Throws 404 when no Library on server matches id'
+      id 'library-data-requirements-05'
+      description 'returns 404 status code with OperationOutcome when no Library exists with passed-in id'
+
+      run do
+        fhir_operation('Library/INVALID_ID/$data-requirements')
+        assert_response_status(404)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Throws 400 when no id, url, or identifier provided'
+      id 'library-data-requirements-06'
+      description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
+
+      run do
+        fhir_operation('Library/$data-requirements')
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+
+    test do
+      title 'Throws 400 when id is included in both the path and as a FHIR parameter'
+      id 'library-data-requirements-07'
+      description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
+      input :library_id, title: 'Library id'
+      run do
+        params_hash = {
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id',
+              valueUrl: library_id }
+          ]
+        }.freeze
+
+        params = FHIR::Parameters.new params_hash
+        fhir_operation("Library/#{library_id}/$data-requirements", body: params)
+        assert_response_status(400)
+        assert_valid_json(response[:body])
+        assert(resource.resourceType == 'OperationOutcome')
+        assert(resource.issue[0].severity == 'error')
+      end
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/lib/measure_repository_service_test_kit/library_data_requirements.rb
+++ b/lib/measure_repository_service_test_kit/library_data_requirements.rb
@@ -4,7 +4,7 @@ require 'json'
 require_relative '../utils/data_requirements_utils'
 
 module MeasureRepositoryServiceTestKit
-  # tests for Library $package service
+  # tests for $data-requirements operation for Library service
   # rubocop:disable Metrics/ClassLength
   class LibraryDataRequirements < Inferno::TestGroup
     title 'Library $data-requirements'

--- a/lib/measure_repository_service_test_kit/library_data_requirements.rb
+++ b/lib/measure_repository_service_test_kit/library_data_requirements.rb
@@ -88,7 +88,7 @@ module MeasureRepositoryServiceTestKit
       include DataRequirementsUtils
       title '200 response and JSON Bundle body for POST parameters url, identifier, and version in body and id in url'
       id 'library-data-requirements-04'
-      description 'returned repsonse has status code 200.'
+      description 'returned response has status code 200.'
       input :library_id, title: 'Library id'
       input :library_url, title: 'Library url'
       input :library_identifier, title: 'Library identifier'

--- a/lib/utils/data_requirements_utils.rb
+++ b/lib/utils/data_requirements_utils.rb
@@ -9,7 +9,10 @@ module MeasureRepositoryServiceTestKit
 
     def assert_dr_success
       assert_success(:library, 200)
-      assert(!resource.type.coding.find { |c| c.code == 'module-definition' }.nil?)
+      assert(resource.dataRequirement, 'No data requirement created.')
+      assert(!resource.type.coding.find do |c|
+               c.code == 'module-definition'
+             end.nil?, 'Resulting data requirements Library is not type module-definition')
     end
   end
 end

--- a/spec/measure_repository_service_test_kit/library_data_requirements_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_data_requirements_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 200, body: dr_library.to_json)
+      
       result = run(test, url:, library_url:)
       expect(result.result).to eq('pass')
     end
@@ -113,6 +114,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 200, body: dr_library.to_json)
+      
       result = run(test, url:, library_identifier:)
       expect(result.result).to eq('pass')
     end
@@ -162,6 +164,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/#{library_id}/$data-requirements"
       ).to_return(status: 200, body: dr_library.to_json)
+      
       result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
       expect(result.result).to eq('pass')
     end
@@ -228,6 +231,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/INVALID_ID/$data-requirements"
       ).to_return(status: 200, body: library.to_json)
+      
       result = run(test, url:)
       expect(result.result).to eq('fail')
     end
@@ -241,6 +245,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 400, body: error_outcome.to_json)
+      
       result = run(test, url:)
       expect(result.result).to eq('pass')
     end
@@ -250,6 +255,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 200, body: error_outcome.to_json)
+      
       result = run(test, url:)
       expect(result.result).to eq('fail')
     end
@@ -260,6 +266,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 400, body: library.to_json)
+      
       result = run(test, url:)
       expect(result.result).to eq('fail')
     end
@@ -274,6 +281,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
       :post,
       "#{url}/Library/#{library_id}/$data-requirements"
     ).to_return(status: 400, body: error_outcome.to_json)
+    
     result = run(test, url:, library_id:)
     expect(result.result).to eq('pass')
   end
@@ -283,6 +291,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
       :post,
       "#{url}/Library/#{library_id}/$data-requirements"
     ).to_return(status: 200, body: error_outcome.to_json)
+    
     result = run(test, url:, library_id:)
     expect(result.result).to eq('fail')
   end
@@ -293,6 +302,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
       :post,
       "#{url}/Library/#{library_id}/$data-requirements"
     ).to_return(status: 400, body: library.to_json)
+    
     result = run(test, url:, library_id:)
     expect(result.result).to eq('fail')
   end

--- a/spec/measure_repository_service_test_kit/library_data_requirements_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_data_requirements_spec.rb
@@ -61,13 +61,24 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
   describe 'Server successfully returns a $data-requirements Library with url in body' do
     let(:test) { group.tests[1] }
     let(:library_url) { 'library_url' }
+    let(:library_version) { 'library_version' }
 
-    it 'passes if a 200 is returned with module-definition library body' do
+    it 'passes if a 200 is returned with module-definition library body, given url and version' do
       stub_request(
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 200, body: dr_library.to_json)
-      
+
+      result = run(test, url:, library_url:, library_version:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes if a 200 is returned with module-definition library body, given just url' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 200, body: dr_library.to_json)
+
       result = run(test, url:, library_url:)
       expect(result.result).to eq('pass')
     end
@@ -78,7 +89,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         "#{url}/Library/$data-requirements"
       ).to_return(status: 400, body: dr_library.to_json)
 
-      result = run(test, url:, library_url:)
+      result = run(test, url:, library_url:, library_version:)
       expect(result.result).to eq('fail')
     end
 
@@ -88,7 +99,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         "#{url}/Library/$data-requirements"
       ).to_return(status: 200, body: FHIR::Bundle.new(id: 'bundle_id').to_json)
 
-      result = run(test, url:, library_url:)
+      result = run(test, url:, library_url:, library_version:)
       expect(result.result).to eq('fail')
     end
 
@@ -100,7 +111,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         "#{url}/Library/$data-requirements"
       ).to_return(status: 200, body: other_library.to_json)
 
-      result = run(test, url:, library_url:)
+      result = run(test, url:, library_url:, library_version:)
       expect(result.result).to eq('fail')
     end
   end
@@ -114,7 +125,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 200, body: dr_library.to_json)
-      
+
       result = run(test, url:, library_identifier:)
       expect(result.result).to eq('pass')
     end
@@ -164,7 +175,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/#{library_id}/$data-requirements"
       ).to_return(status: 200, body: dr_library.to_json)
-      
+
       result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
       expect(result.result).to eq('pass')
     end
@@ -231,7 +242,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/INVALID_ID/$data-requirements"
       ).to_return(status: 200, body: library.to_json)
-      
+
       result = run(test, url:)
       expect(result.result).to eq('fail')
     end
@@ -245,7 +256,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 400, body: error_outcome.to_json)
-      
+
       result = run(test, url:)
       expect(result.result).to eq('pass')
     end
@@ -255,7 +266,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 200, body: error_outcome.to_json)
-      
+
       result = run(test, url:)
       expect(result.result).to eq('fail')
     end
@@ -266,44 +277,45 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
         :post,
         "#{url}/Library/$data-requirements"
       ).to_return(status: 400, body: library.to_json)
-      
+
       result = run(test, url:)
       expect(result.result).to eq('fail')
     end
   end
 
-  describe 'Server returns 400 when id is included in both the path and as a FHIR parameter'
-  let(:test) { group.tests[6] }
-  let(:library_id) { 'library_id' }
+  describe 'Server returns 400 when id is included in both the path and as a FHIR parameter' do
+    let(:test) { group.tests[6] }
+    let(:library_id) { 'library_id' }
 
-  it 'passes when 400 returned with OperationOutcome' do
-    stub_request(
-      :post,
-      "#{url}/Library/#{library_id}/$data-requirements"
-    ).to_return(status: 400, body: error_outcome.to_json)
-    
-    result = run(test, url:, library_id:)
-    expect(result.result).to eq('pass')
-  end
+    it 'passes when 400 returned with OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 400, body: error_outcome.to_json)
 
-  it 'fails if 200 status code returned' do
-    stub_request(
-      :post,
-      "#{url}/Library/#{library_id}/$data-requirements"
-    ).to_return(status: 200, body: error_outcome.to_json)
-    
-    result = run(test, url:, library_id:)
-    expect(result.result).to eq('fail')
-  end
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('pass')
+    end
 
-  it 'fails if library body returned' do
-    library = FHIR::Library.new
-    stub_request(
-      :post,
-      "#{url}/Library/#{library_id}/$data-requirements"
-    ).to_return(status: 400, body: library.to_json)
-    
-    result = run(test, url:, library_id:)
-    expect(result.result).to eq('fail')
+    it 'fails if 200 status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 200, body: error_outcome.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if library body returned' do
+      library = FHIR::Library.new
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 400, body: library.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
   end
 end

--- a/spec/measure_repository_service_test_kit/library_data_requirements_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_data_requirements_spec.rb
@@ -1,0 +1,299 @@
+# frozen_string_literal: true
+
+require_relative '../utils/spec_utils'
+
+RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find('measure_repository_service_test_suite') }
+  let(:group) { suite.groups[6] }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:url) { 'http://example.com/fhir' }
+  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+  let(:dr_library) { FHIR::Library.new({ type: { coding: [{ code: 'module-definition' }] }, dataRequirement: [] }) }
+
+  describe 'Server successfully returns a $data-requirements Library with id in url' do
+    let(:test) { group.tests.first }
+    let(:library_id) { 'library_id' }
+
+    it 'passes if a 200 is returned with module-definition library body' do
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 200, body: dr_library.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 400, body: dr_library.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if body is not a Library' do
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 200, body: FHIR::Bundle.new(id: 'bundle_id').to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Library in returned bundle is not of type module-definition' do
+      other_library = dr_library.clone
+      other_library.type.coding[0].code = 'logic-library'
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 200, body: other_library.to_json)
+
+      result = run(test, url:, library_id:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully returns a $data-requirements Library with url in body' do
+    let(:test) { group.tests[1] }
+    let(:library_url) { 'library_url' }
+
+    it 'passes if a 200 is returned with module-definition library body' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 200, body: dr_library.to_json)
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 400, body: dr_library.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if body is not a Library' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 200, body: FHIR::Bundle.new(id: 'bundle_id').to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Library in returned bundle is not of type module-definition' do
+      other_library = dr_library.clone
+      other_library.type.coding[0].code = 'logic-library'
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 200, body: other_library.to_json)
+
+      result = run(test, url:, library_url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully returns bundle on Library $package with identifier in body' do
+    let(:test) { group.tests[2] }
+    let(:library_identifier) { 'identifier_system|identifier_value' }
+
+    it 'passes if a 200 is returned with module-definition library body' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 200, body: dr_library.to_json)
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 400, body: dr_library.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if body is not a Library' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 200, body: FHIR::Bundle.new(id: 'bundle_id').to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Library in returned bundle is not of type module-definition' do
+      other_library = dr_library.clone
+      other_library.type.coding[0].code = 'logic-library'
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 200, body: other_library.to_json)
+
+      result = run(test, url:, library_identifier:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server successfully returns bundle on Library $package with url, identifier, and version in body' do
+    let(:test) { group.tests[3] }
+    let(:library_id) { 'library_id' }
+    let(:library_identifier) { 'identifier_system|identifier_value' }
+    let(:library_url) { 'library_url' }
+    let(:library_version) { 'library_version' }
+
+    it 'passes if a 200 is returned with module-definition library body' do
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 200, body: dr_library.to_json)
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if a 200 is not returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 400, body: dr_library.to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if body is not a Library' do
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 200, body: FHIR::Bundle.new(id: 'bundle_id').to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if Library in returned bundle is not of type module-definition' do
+      other_library = dr_library.clone
+      other_library.type.coding[0].code = 'logic-library'
+      stub_request(
+        :post,
+        "#{url}/Library/#{library_id}/$data-requirements"
+      ).to_return(status: 200, body: other_library.to_json)
+
+      result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server returns 404 when no library matches id' do
+    let(:test) { group.tests[4] }
+
+    it 'passses when 404 returned with OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Library/INVALID_ID/$data-requirements"
+      ).to_return(status: 404, body: error_outcome.to_json)
+
+      result = run(test, url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if 200 status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/INVALID_ID/$data-requirements"
+      ).to_return(status: 200, body: error_outcome.to_json)
+
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if library returned' do
+      library = FHIR::Library.new
+      stub_request(
+        :post,
+        "#{url}/Library/INVALID_ID/$data-requirements"
+      ).to_return(status: 200, body: library.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server returns 400 when no id, url, or identifier provided' do
+    let(:test) { group.tests[5] }
+
+    it 'passes when 400 returned with OperationOutcome' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 400, body: error_outcome.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if 200 status code returned' do
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 200, body: error_outcome.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if library body returned' do
+      library = FHIR::Library.new
+      stub_request(
+        :post,
+        "#{url}/Library/$data-requirements"
+      ).to_return(status: 400, body: library.to_json)
+      result = run(test, url:)
+      expect(result.result).to eq('fail')
+    end
+  end
+
+  describe 'Server returns 400 when id is included in both the path and as a FHIR parameter'
+  let(:test) { group.tests[6] }
+  let(:library_id) { 'library_id' }
+
+  it 'passes when 400 returned with OperationOutcome' do
+    stub_request(
+      :post,
+      "#{url}/Library/#{library_id}/$data-requirements"
+    ).to_return(status: 400, body: error_outcome.to_json)
+    result = run(test, url:, library_id:)
+    expect(result.result).to eq('pass')
+  end
+
+  it 'fails if 200 status code returned' do
+    stub_request(
+      :post,
+      "#{url}/Library/#{library_id}/$data-requirements"
+    ).to_return(status: 200, body: error_outcome.to_json)
+    result = run(test, url:, library_id:)
+    expect(result.result).to eq('fail')
+  end
+
+  it 'fails if library body returned' do
+    library = FHIR::Library.new
+    stub_request(
+      :post,
+      "#{url}/Library/#{library_id}/$data-requirements"
+    ).to_return(status: 400, body: library.to_json)
+    result = run(test, url:, library_id:)
+    expect(result.result).to eq('fail')
+  end
+end


### PR DESCRIPTION
# Summary
Library $data-requirements test suite

## New behavior
Added test suite tests accepted parameters and expected errors for Library $data-requirements

## Code changes
 - `library_data_requirements.rb` file containing 7 new tests
 - `library_data_requirements_spec.rb` for testing new suite
 - Updated `measure_repository_service_test_kit.rb` to include new test suite

# Testing guidance
 - `rspec`
 - Start up the test kit with the instruction in the readme
 - In `measure-repository-service`
 - `npm run db:reset`
 - To add Library identifier, head into `ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json` and find the `Library` resource in the bundle with `"id": "ColorectalCancerScreeningsFHIR"`. 
 - Add the following code snippet to the `Library`: 
 ```
        "identifier": {
          "system": "testSystem",
          "value": "testCode"
        }
```
 - `npm run db:loadBundle "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json"`
 - `npm start`
 - Navigate to `http://localhost:4567`
 - Select the Library $data-requirements suite
 - Click "run all tests"
 - Enter the following information for each field: 
 - Library id: `ColorectalCancerScreeningsFHIR`
 - FHIR Server Base: `http://localhost:3000`
 - Library url: `http://ecqi.healthit.gov/ecqms/Library/ColorectalCancerScreeningsFHIR`
 - Library Identifier: `testCode`
 - Library version: `0.0.003`
 - Make sure all tests pass!
<img width="541" alt="Screen Shot 2023-02-22 at 7 47 50 AM" src="https://user-images.githubusercontent.com/2643955/220774499-f2e4314d-c936-4c45-b79c-e387cb6a5679.png">

 
 