### PR TITLE
Update search by version tests to require url input

### DIFF
--- a/lib/measure_repository_service_test_kit/library_group.rb
+++ b/lib/measure_repository_service_test_kit/library_group.rb
@@ -84,16 +84,20 @@ module MeasureRepositoryServiceTestKit
       matching a version'
       id 'read-and-search-library-04'
       description %(This test verifies that a Library resource can be found through search by version from
-      the server.)
+      the server. Note that version can only be supplied with a url.)
+      input :library_url, title: 'Library url'
       input :library_version, title: 'Library version'
 
       run do
-        fhir_search(:library, params: { version: library_version })
+        fhir_search(:library, params: { url: library_url, version: library_version })
 
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         assert(!resource.entry[0].nil?, 'Search by version returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.url == library_url,
+               "Requested resource with url #{library_url}, received resource with
+               url #{resource.entry[0].resource.url}"
         assert resource.entry[0].resource.version == library_version, "Requested resource with
         version #{library_version}, received resource with version #{resource.entry[0].resource.version}"
       end

--- a/lib/measure_repository_service_test_kit/measure_group.rb
+++ b/lib/measure_repository_service_test_kit/measure_group.rb
@@ -85,16 +85,20 @@ module MeasureRepositoryServiceTestKit
       matching a version'
       id 'read-and-search-measure-04'
       description %(This test verifies that a Measure resource can be found through search by version
-      from the server.)
+      from the server. Note that version can only be supplied with a url.)
+      input :measure_url, title: 'Measure url'
       input :measure_version, title: 'Measure version'
 
       run do
-        fhir_search(:measure, params: { version: measure_version })
+        fhir_search(:measure, params: { url: measure_url, version: measure_version })
 
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
         assert(!resource.entry[0].nil?, 'Search by version returned an empty FHIR searchset bundle')
+        assert resource.entry[0].resource.url == measure_url,
+               "Requested resource with url #{measure_url}, received resource with
+                url #{resource.entry[0].resource.url}"
         assert resource.entry[0].resource.version == measure_version, "Requested resource with version
          #{measure_version}, received resource with version #{resource.entry[0].resource.version}"
       end

--- a/spec/measure_repository_service_test_kit/library_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_group_spec.rb
@@ -144,53 +144,54 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryGroup do
 
   describe 'Server successfully searches and retrieves Library by its version' do
     let(:test) { group.tests[3] }
+    let(:library_url) { 'library_url' }
     let(:library_version) { 'library_version' }
 
     it 'passes if the libraries in the returned FHIR searchset bundle match the requested version' do
-      library = FHIR::Library.new(version: library_version)
+      library = FHIR::Library.new(url: library_url, version: library_version)
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :get,
-        "#{url}/Library?version=#{library_version}"
+        "#{url}/Library?url=#{library_url}&version=#{library_version}"
       ).to_return(status: 200, body: bundle.to_json)
 
-      result = run(test, url:, library_version:)
+      result = run(test, url:, library_url:, library_version:)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if search does not return 200' do
-      library =  FHIR::Library.new(version: library_version)
+      library =  FHIR::Library.new(url: library_url, version: library_version)
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :get,
-        "#{url}/Library?version=#{library_version}"
+        "#{url}/Library?url=#{library_url}&version=#{library_version}"
       ).to_return(status: 400, body: bundle.to_json)
 
-      result = run(test, url:, library_version:)
+      result = run(test, url:, library_url:, library_version:)
       expect(result.result).to eq('fail')
     end
 
     it 'fails if the libraries in the returned FHIR searchset bundle do not match the
       requested version' do
-      library = FHIR::Library.new(version: 'INVALID_VERSION')
+      library = FHIR::Library.new(url: library_url, version: 'INVALID_VERSION')
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :get,
-        "#{url}/Library?version=#{library_version}"
+        "#{url}/Library?url=#{library_url}&version=#{library_version}"
       ).to_return(status: 200, body: bundle.to_json)
 
-      result = run(test, url:, library_version:)
+      result = run(test, url:, library_url:, library_version:)
       expect(result.result).to eq('fail')
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      library =  FHIR::Library.new(version: library_version)
+      library =  FHIR::Library.new(url: library_url, version: library_version)
       stub_request(
         :get,
-        "#{url}/Library?version=#{library_version}"
+        "#{url}/Library?url=#{library_url}&version=#{library_version}"
       ).to_return(status: 200, body: library.to_json)
 
-      result = run(test, url:, library_version:)
+      result = run(test, url:, library_url:, library_version:)
       expect(result.result).to eq('fail')
     end
   end

--- a/spec/measure_repository_service_test_kit/measure_group_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_group_spec.rb
@@ -144,53 +144,54 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasureGroup do
 
   describe 'Server successfully searches and retrieves Measure by its version' do
     let(:test) { group.tests[3] }
+    let(:measure_url) { 'measure_url' }
     let(:measure_version) { 'measure_version' }
 
     it 'passes if the measures in the returned FHIR searchset bundle match the requested version' do
-      measure = FHIR::Measure.new(version: measure_version)
+      measure = FHIR::Measure.new(url: measure_url, version: measure_version)
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :get,
-        "#{url}/Measure?version=#{measure_version}"
+        "#{url}/Measure?url=#{measure_url}&version=#{measure_version}"
       ).to_return(status: 200, body: bundle.to_json)
 
-      result = run(test, url:, measure_version:)
+      result = run(test, url:, measure_url:, measure_version:)
       expect(result.result).to eq('pass')
     end
 
     it 'fails if search does not return 200' do
-      measure =  FHIR::Measure.new(version: measure_version)
+      measure =  FHIR::Measure.new(url: measure_url, version: measure_version)
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :get,
-        "#{url}/Measure?version=#{measure_version}"
+        "#{url}/Measure?url=#{measure_url}&version=#{measure_version}"
       ).to_return(status: 400, body: bundle.to_json)
 
-      result = run(test, url:, measure_version:)
+      result = run(test, url:, measure_url:, measure_version:)
       expect(result.result).to eq('fail')
     end
 
     it 'fails if the measures in the returned FHIR searchset bundle do not match the
       requested version' do
-      measure = FHIR::Measure.new(version: 'INVALID_VERSION')
+      measure = FHIR::Measure.new(url: measure_url, version: 'INVALID_VERSION')
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :get,
-        "#{url}/Measure?version=#{measure_version}"
+        "#{url}/Measure?url=#{measure_url}&version=#{measure_version}"
       ).to_return(status: 200, body: bundle.to_json)
 
-      result = run(test, url:, measure_version:)
+      result = run(test, url:, measure_url:, measure_version:)
       expect(result.result).to eq('fail')
     end
 
     it 'fails if the search request does not return a FHIR searchset bundle' do
-      measure =  FHIR::Measure.new(version: measure_version)
+      measure =  FHIR::Measure.new(url: measure_url, version: measure_version)
       stub_request(
         :get,
-        "#{url}/Measure?version=#{measure_version}"
+        "#{url}/Measure?url=#{measure_url}&version=#{measure_version}"
       ).to_return(status: 200, body: measure.to_json)
 
-      result = run(test, url:, measure_version:)
+      result = run(test, url:, measure_url:, measure_version:)
       expect(result.result).to eq('fail')
     end
   end


### PR DESCRIPTION
# Summary
Updates Measure/Library search tests with `version` param to also require a `url`. See https://github.com/projecttacoma/measure-repository-service/pull/21 for context on the changes made to the measure repository service.

## New behavior
Search tests that verify Library/Measure resources can be found through search by version now require that a `url` be specified as an input to the tests.

## Code changes
* Updates to the version search tests in `lib/../library_group.rb` and `lib/../measure_group.rb`
* Updates to corresponding `rspec` tests to take in `url` when `version` is supplied

I figured this requirement is minor enough that we do not need tests that explicitly check for the presence of a url when version is specified (i.e. checking that the 400 is thrown), but open to what others think about this.

# Testing Guidance
* Run `rspec` tests
* Run the measure repository service from the `search-version` branch (which corresponds to the changes made in [this PR]( https://github.com/projecttacoma/measure-repository-service/pull/21)). Run the Measure/Library search tests for search by version. Use the following inputs (assuming the ColorectalCancerScreeningsFHIR measure bundle is loaded up on the server):

**Library url:** http://ecqi.healthit.gov/ecqms/Library/ColorectalCancerScreeningsFHIR
**Library version:** 0.0.003

**Measure url:** http://ecqi.healthit.gov/ecqms/Measure/ColorectalCancerScreeningsFHIR
**Measure version:** 0.0.003