### PR TITLE
content-type application/fhir+json

### DIFF
--- a/lib/measure_repository_service_test_kit/library_package.rb
+++ b/lib/measure_repository_service_test_kit/library_package.rb
@@ -14,9 +14,11 @@ module MeasureRepositoryServiceTestKit
     title 'Library $package'
     description 'Ensure measure repository service can execute the $package operation to the Library endpoint'
     id 'library_package'
+    custom_headers = { 'content-type': 'application/fhir+json' }
 
     fhir_client do
       url :url
+      headers custom_headers
     end
 
     test do

--- a/lib/measure_repository_service_test_kit/measure_data_requirements.rb
+++ b/lib/measure_repository_service_test_kit/measure_data_requirements.rb
@@ -11,9 +11,11 @@ module MeasureRepositoryServiceTestKit
     title 'Measure $data-requirements'
     description 'Ensure measure repository service can run Measure/$data-requirements operation'
     id 'measure_data_requirements'
+    custom_headers = { 'content-type': 'application/fhir+json' }
 
     fhir_client do
       url :url
+      headers custom_headers
     end
 
     INVALID_ID = 'INVALID_ID'

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -14,9 +14,11 @@ module MeasureRepositoryServiceTestKit
     title 'Measure $package'
     description 'Ensure measure repository service can execute the $package operation to the Measure endpoint'
     id 'measure_package'
+    custom_headers = { 'content-type': 'application/fhir+json' }
 
     fhir_client do
       url :url
+      headers custom_headers
     end
 
     test do


### PR DESCRIPTION
# Summary
Updates the fhir_client to always have `content-type: application/fhir+json` for `POST` operations
## New behavior
`fhir_operation` only sets the `content-type` header when the request contains a body. This led to errors in measure-repository-service, as we check for content-type header on all `POST` requests. This update should fix all the tests. 

## Code changes
Added custom headers to all fhir_clients in suites that execute `POST` requests

# Testing guidance
 - `rubocop`
 - `rspec`
 - Run all tests with inputs from #2, #3, #4, #6, #7, and #9 and make sure all pass
