### PR TITLE
Update endpoints to $cqfm.package

### DIFF
--- a/lib/measure_repository_service_test_kit/library_package.rb
+++ b/lib/measure_repository_service_test_kit/library_package.rb
@@ -5,14 +5,14 @@ require_relative '../utils/package_utils'
 require_relative '../utils/general_utils'
 
 module MeasureRepositoryServiceTestKit
-  # tests for Library $package service
+  # tests for Library $cqfm.package service
   # rubocop:disable Metrics/ClassLength
   class LibraryPackage < Inferno::TestGroup
     include PackageUtils
     include GeneralUtils
 
-    title 'Library $package'
-    description 'Ensure measure repository service can execute the $package operation to the Library endpoint'
+    title 'Library $cqfm.package'
+    description 'Ensure measure repository service can execute the $cqfm.package operation to the Library endpoint'
     id 'library_package'
     custom_headers = { 'content-type': 'application/fhir+json' }
 
@@ -28,7 +28,7 @@ module MeasureRepositoryServiceTestKit
       input :library_id, title: 'Library id'
       makes_request :library_package
       run do
-        fhir_operation("Library/#{library_id}/$package", name: :library_package)
+        fhir_operation("Library/#{library_id}/$cqfm.package", name: :library_package)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
@@ -54,7 +54,7 @@ module MeasureRepositoryServiceTestKit
 
         params = FHIR::Parameters.new params_hash
 
-        fhir_operation('Library/$package', body: params)
+        fhir_operation('Library/$cqfm.package', body: params)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
@@ -80,7 +80,7 @@ module MeasureRepositoryServiceTestKit
 
         params = FHIR::Parameters.new params_hash
 
-        fhir_operation('Library/$package', body: params)
+        fhir_operation('Library/$cqfm.package', body: params)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
@@ -114,7 +114,7 @@ module MeasureRepositoryServiceTestKit
 
         params = FHIR::Parameters.new params_hash
 
-        fhir_operation("Library/#{library_id}/$package", body: params)
+        fhir_operation("Library/#{library_id}/$cqfm.package", body: params)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
@@ -148,7 +148,7 @@ module MeasureRepositoryServiceTestKit
       description 'returns 404 status code with OperationOutcome when no Library exists with passed-in id'
 
       run do
-        fhir_operation('Library/INVALID_ID/$package')
+        fhir_operation('Library/INVALID_ID/$cqfm.package')
         assert_response_status(404)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
@@ -162,7 +162,7 @@ module MeasureRepositoryServiceTestKit
       description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
 
       run do
-        fhir_operation('Library/$package')
+        fhir_operation('Library/$cqfm.package')
         assert_response_status(400)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
@@ -179,7 +179,7 @@ module MeasureRepositoryServiceTestKit
       input :library_id, title: 'Library id'
 
       run do
-        fhir_operation("Library/#{library_id}/$package?include-terminology=true")
+        fhir_operation("Library/#{library_id}/$cqfm.package?include-terminology=true")
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])

--- a/lib/measure_repository_service_test_kit/measure_package.rb
+++ b/lib/measure_repository_service_test_kit/measure_package.rb
@@ -5,14 +5,14 @@ require_relative '../utils/package_utils'
 require_relative '../utils/general_utils'
 
 module MeasureRepositoryServiceTestKit
-  # tests for Measure $package service
+  # tests for Measure $cqfm.package service
   # rubocop:disable Metrics/ClassLength
   class MeasurePackage < Inferno::TestGroup
     include PackageUtils
     include GeneralUtils
 
-    title 'Measure $package'
-    description 'Ensure measure repository service can execute the $package operation to the Measure endpoint'
+    title 'Measure $cqfm.package'
+    description 'Ensure measure repository service can execute the $cqfm.package operation to the Measure endpoint'
     id 'measure_package'
     custom_headers = { 'content-type': 'application/fhir+json' }
 
@@ -28,7 +28,7 @@ module MeasureRepositoryServiceTestKit
       input :measure_id, title: 'Measure id'
       makes_request :measure_package
       run do
-        fhir_operation("Measure/#{measure_id}/$package", name: :measure_package)
+        fhir_operation("Measure/#{measure_id}/$cqfm.package", name: :measure_package)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
@@ -54,7 +54,7 @@ module MeasureRepositoryServiceTestKit
 
         params = FHIR::Parameters.new params_hash
 
-        fhir_operation('Measure/$package', body: params)
+        fhir_operation('Measure/$cqfm.package', body: params)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
@@ -80,7 +80,7 @@ module MeasureRepositoryServiceTestKit
 
         params = FHIR::Parameters.new params_hash
 
-        fhir_operation('Measure/$package', body: params)
+        fhir_operation('Measure/$cqfm.package', body: params)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
@@ -119,7 +119,7 @@ module MeasureRepositoryServiceTestKit
 
         params = FHIR::Parameters.new params_hash
 
-        fhir_operation("Measure/#{measure_id}/$package", body: params)
+        fhir_operation("Measure/#{measure_id}/$cqfm.package", body: params)
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])
@@ -154,7 +154,7 @@ module MeasureRepositoryServiceTestKit
       description 'returns 404 status code with OperationOutcome when no Measure exists with passed-in id'
 
       run do
-        fhir_operation('Measure/INVALID_ID/$package')
+        fhir_operation('Measure/INVALID_ID/$cqfm.package')
         assert_response_status(404)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
@@ -168,7 +168,7 @@ module MeasureRepositoryServiceTestKit
       description 'returns 400 status code with OperationOutcome when no id, url, or identifier provided'
 
       run do
-        fhir_operation('Measure/$package')
+        fhir_operation('Measure/$cqfm.package')
         assert_response_status(400)
         assert_valid_json(response[:body])
         assert(resource.resourceType == 'OperationOutcome')
@@ -185,7 +185,7 @@ module MeasureRepositoryServiceTestKit
       input :measure_id, title: 'Measure id'
 
       run do
-        fhir_operation("Measure/#{measure_id}/$package?include-terminology=true")
+        fhir_operation("Measure/#{measure_id}/$cqfm.package?include-terminology=true")
         assert_response_status(200)
         assert_resource_type(:bundle)
         assert_valid_json(response[:body])

--- a/lib/utils/package_utils.rb
+++ b/lib/utils/package_utils.rb
@@ -3,7 +3,7 @@
 require 'set'
 
 module MeasureRepositoryServiceTestKit
-  # Utility functions in support of the $package test group
+  # Utility functions in support of the $cqfm.package test group
   module PackageUtils
     def related_artifacts_present?(bundle, should_check_valuesets)
       artifact_urls = Set[]

--- a/spec/measure_repository_service_test_kit/library_data_requirements_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_data_requirements_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
     end
   end
 
-  describe 'Server successfully returns bundle on Library $package with identifier in body' do
+  describe 'Server successfully returns bundle on Library $cqfm.package with identifier in body' do
     let(:test) { group.tests[2] }
     let(:library_identifier) { 'identifier_system|identifier_value' }
 
@@ -163,7 +163,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryDataRequirements do
     end
   end
 
-  describe 'Server successfully returns bundle on Library $package with url, identifier, and version in body' do
+  describe 'Server successfully returns bundle on Library $cqfm.package with url, identifier, and version in body' do
     let(:test) { group.tests[3] }
     let(:library_id) { 'library_id' }
     let(:library_identifier) { 'identifier_system|identifier_value' }

--- a/spec/measure_repository_service_test_kit/library_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/library_package_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 
-  describe 'Server successfully returns bundle on Library $package with id in url' do
+  describe 'Server successfully returns bundle on Library $cqfm.package with id in url' do
     let(:test) { group.tests.first }
     let(:library_id) { 'library_id' }
 
@@ -19,7 +19,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:)
@@ -31,7 +31,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 400, body: bundle.to_json)
 
       result = run(test, url:, library_id:)
@@ -42,7 +42,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       library = FHIR::Library.new(id: library_id)
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 400, body: library.to_json)
 
       result = run(test, url:, library_id:)
@@ -54,7 +54,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:)
@@ -62,7 +62,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
     end
   end
 
-  describe 'Server successfully returns bundle on Measure $package with url in body' do
+  describe 'Server successfully returns bundle on Measure $cqfm.package with url in body' do
     let(:test) { group.tests[1] }
     let(:library_url) { 'library_url' }
 
@@ -72,7 +72,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
 
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, library_url:)
       expect(result.result).to eq('pass')
@@ -83,7 +83,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Library.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 400, body: bundle.to_json)
 
       result = run(test, url:, library_url:)
@@ -94,7 +94,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       library = FHIR::Library.new(url: library_url)
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 400, body: library.to_json)
 
       result = run(test, url:, library_url:)
@@ -106,7 +106,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_url:)
@@ -114,7 +114,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
     end
   end
 
-  describe 'Server successfully returns bundle on Library $package with identifier in body' do
+  describe 'Server successfully returns bundle on Library $cqfm.package with identifier in body' do
     let(:test) { group.tests[2] }
     let(:library_identifier) { 'identifier_system|identifier_value' }
     let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
@@ -124,7 +124,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_identifier:)
@@ -136,7 +136,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 400, body: bundle.to_json)
 
       result = run(test, url:, library_identifier:)
@@ -147,7 +147,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       library = FHIR::Library.new(identifier: expected_identifier)
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 400, body: library.to_json)
 
       result = run(test, url:, library_identifier:)
@@ -159,7 +159,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_identifier:)
@@ -171,7 +171,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_identifier:)
@@ -179,7 +179,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
     end
   end
 
-  describe 'Server successfully returns bundle on Library $package with url, identifier, and version in body' do
+  describe 'Server successfully returns bundle on Library $cqfm.package with url, identifier, and version in body' do
     let(:test) { group.tests[3] }
     let(:library_id) { 'library_id' }
     let(:library_identifier) { 'identifier_system|identifier_value' }
@@ -193,7 +193,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
@@ -206,7 +206,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
@@ -219,7 +219,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
@@ -232,7 +232,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
@@ -246,7 +246,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
@@ -260,7 +260,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package"
+        "#{url}/Library/#{library_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:, library_url:, library_identifier:, library_version:)
@@ -281,7 +281,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       repo_create(
         :request,
         name: 'library_package',
-        url: "http://example.com/Library/#{library_id}/$package",
+        url: "http://example.com/Library/#{library_id}/$cqfm.package",
         test_session_id: test_session.id,
         status: 200,
         response_body: bundle.to_json
@@ -296,7 +296,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       repo_create(
         :request,
         name: 'library_package',
-        url: "http://example.com/Library/#{library_id}/$package",
+        url: "http://example.com/Library/#{library_id}/$cqfm.package",
         test_session_id: test_session.id,
         status: 200,
         response_body: bundle.to_json
@@ -319,7 +319,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
     it 'passses when 404 returned with OperationOutcome' do
       stub_request(
         :post,
-        "#{url}/Library/INVALID_ID/$package"
+        "#{url}/Library/INVALID_ID/$cqfm.package"
       ).to_return(status: 404, body: error_outcome.to_json)
 
       result = run(test, url:)
@@ -329,7 +329,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
     it 'fails if 200 status code returned' do
       stub_request(
         :post,
-        "#{url}/Library/INVALID_ID/$package"
+        "#{url}/Library/INVALID_ID/$cqfm.package"
       ).to_return(status: 200, body: error_outcome.to_json)
 
       result = run(test, url:)
@@ -340,7 +340,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new
       stub_request(
         :post,
-        "#{url}/Library/INVALID_ID/$package"
+        "#{url}/Library/INVALID_ID/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:)
       expect(result.result).to eq('fail')
@@ -354,7 +354,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
     it 'passes when 400 returned with OperationOutcome' do
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url:)
       expect(result.result).to eq('pass')
@@ -363,7 +363,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
     it 'fails if 200 status code returned' do
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:)
       expect(result.result).to eq('fail')
@@ -373,7 +373,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
       bundle = FHIR::Bundle.new
       stub_request(
         :post,
-        "#{url}/Library/$package"
+        "#{url}/Library/$cqfm.package"
       ).to_return(status: 400, body: bundle.to_json)
       result = run(test, url:)
       expect(result.result).to eq('fail')
@@ -399,7 +399,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
                                         { resource: dep_library }, { resource: dep_valueset }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package?include-terminology=true"
+        "#{url}/Library/#{library_id}/$cqfm.package?include-terminology=true"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:)
@@ -412,7 +412,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
                                         { resource: dep_library }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package?include-terminology=true"
+        "#{url}/Library/#{library_id}/$cqfm.package?include-terminology=true"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:)
@@ -424,7 +424,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::LibraryPackage do
                                 entry: [{ resource: library }, { resource: dep_valueset }])
       stub_request(
         :post,
-        "#{url}/Library/#{library_id}/$package?include-terminology=true"
+        "#{url}/Library/#{library_id}/$cqfm.package?include-terminology=true"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, library_id:)

--- a/spec/measure_repository_service_test_kit/measure_package_spec.rb
+++ b/spec/measure_repository_service_test_kit/measure_package_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
   let(:url) { 'http://example.com/fhir' }
   let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
 
-  describe 'Server successfully returns bundle on Measure $package with id in url' do
+  describe 'Server successfully returns bundle on Measure $cqfm.package with id in url' do
     let(:test) { group.tests.first }
     let(:measure_id) { 'measure_id' }
 
@@ -19,7 +19,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, measure_id:)
@@ -31,7 +31,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 400, body: bundle.to_json)
 
       result = run(test, url:, measure_id:)
@@ -42,7 +42,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       measure = FHIR::Measure.new(id: measure_id)
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 400, body: measure.to_json)
 
       result = run(test, url:, measure_id:)
@@ -54,7 +54,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, measure_id:)
@@ -62,7 +62,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     end
   end
 
-  describe 'Server successfully returns bundle on Measure $package with url in body' do
+  describe 'Server successfully returns bundle on Measure $cqfm.package with url in body' do
     let(:test) { group.tests[1] }
     let(:measure_url) { 'measure_url' }
 
@@ -72,7 +72,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
 
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, measure_url:)
       expect(result.result).to eq('pass')
@@ -83,7 +83,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 400, body: bundle.to_json)
 
       result = run(test, url:, measure_url:)
@@ -94,7 +94,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       measure = FHIR::Measure.new(url: measure_url)
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 400, body: measure.to_json)
 
       result = run(test, url:, measure_url:)
@@ -106,7 +106,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, measure_url:)
@@ -114,7 +114,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     end
   end
 
-  describe 'Server successfully returns bundle on Measure $package with identifier in body' do
+  describe 'Server successfully returns bundle on Measure $cqfm.package with identifier in body' do
     let(:test) { group.tests[2] }
     let(:measure_identifier) { 'identifier_system|identifier_value' }
     let(:expected_identifier) { { system: 'identifier_system', value: 'identifier_value' } }
@@ -125,7 +125,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
 
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, measure_identifier:)
       expect(result.result).to eq('pass')
@@ -136,7 +136,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 400, body: bundle.to_json)
 
       result = run(test, url:, measure_identifier:)
@@ -147,7 +147,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       measure = FHIR::Measure.new(identifier: expected_identifier)
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 400, body: measure.to_json)
 
       result = run(test, url:, measure_identifier:)
@@ -159,7 +159,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, measure_identifier:)
@@ -171,7 +171,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new(total: 1, entry: [{ resource: measure }])
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, measure_identifier:)
@@ -179,7 +179,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     end
   end
 
-  describe 'Server successfully returns bundle on Measure $package with url, identifier, and version in body' do
+  describe 'Server successfully returns bundle on Measure $cqfm.package with url, identifier, and version in body' do
     let(:test) { group.tests[3] }
     let(:measure_id) { 'measure_id' }
     let(:measure_identifier) { 'identifier_system|identifier_value' }
@@ -194,7 +194,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, measure_id:, measure_url:, measure_identifier:, measure_version:)
       expect(result.result).to eq('pass')
@@ -207,7 +207,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, measure_id:, measure_url:, measure_identifier:,
                          measure_version:)
@@ -221,7 +221,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, measure_id:, measure_url:, measure_identifier:,
                          measure_version:)
@@ -235,7 +235,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, measure_id:, measure_url:, measure_identifier:,
                          measure_version:)
@@ -250,7 +250,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, measure_id:, measure_url:, measure_identifier:,
                          measure_version:)
@@ -265,7 +265,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
 
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package"
+        "#{url}/Measure/#{measure_id}/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:, measure_id:, measure_url:, measure_identifier:,
                          measure_version:)
@@ -289,7 +289,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       repo_create(
         :request,
         name: 'measure_package',
-        url: "http://example.com/Measure/#{measure_id}/$package",
+        url: "http://example.com/Measure/#{measure_id}/$cqfm.package",
         test_session_id: test_session.id,
         status: 200,
         response_body: bundle.to_json
@@ -304,7 +304,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       repo_create(
         :request,
         name: 'measure_package',
-        url: "http://example.com/Measure/#{measure_id}/$package",
+        url: "http://example.com/Measure/#{measure_id}/$cqfm.package",
         test_session_id: test_session.id,
         status: 200,
         response_body: bundle.to_json
@@ -326,7 +326,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     it 'passes when 404 returned with OperationOutcome' do
       stub_request(
         :post,
-        "#{url}/Measure/INVALID_ID/$package"
+        "#{url}/Measure/INVALID_ID/$cqfm.package"
       ).to_return(status: 404, body: error_outcome.to_json)
       result = run(test, url:)
       expect(result.result).to eq('pass')
@@ -335,7 +335,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     it 'fails if 200 status code returned' do
       stub_request(
         :post,
-        "#{url}/Measure/INVALID_ID/$package"
+        "#{url}/Measure/INVALID_ID/$cqfm.package"
       ).to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:)
       expect(result.result).to eq('fail')
@@ -345,7 +345,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new
       stub_request(
         :post,
-        "#{url}/Measure/INVALID_ID/$package"
+        "#{url}/Measure/INVALID_ID/$cqfm.package"
       ).to_return(status: 200, body: bundle.to_json)
       result = run(test, url:)
       expect(result.result).to eq('fail')
@@ -359,7 +359,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     it 'passes when 400 returned with OperationOutcome' do
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 400, body: error_outcome.to_json)
       result = run(test, url:)
       expect(result.result).to eq('pass')
@@ -368,7 +368,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
     it 'fails if 200 status code returned' do
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 200, body: error_outcome.to_json)
       result = run(test, url:)
       expect(result.result).to eq('fail')
@@ -378,7 +378,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
       bundle = FHIR::Bundle.new
       stub_request(
         :post,
-        "#{url}/Measure/$package"
+        "#{url}/Measure/$cqfm.package"
       ).to_return(status: 400, body: bundle.to_json)
       result = run(test, url:)
       expect(result.result).to eq('fail')
@@ -405,7 +405,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
                                         { resource: dep_library }, { resource: dep_valueset }])
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package?include-terminology=true"
+        "#{url}/Measure/#{measure_id}/$cqfm.package?include-terminology=true"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, measure_id:)
@@ -418,7 +418,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
                                         { resource: dep_library }])
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package?include-terminology=true"
+        "#{url}/Measure/#{measure_id}/$cqfm.package?include-terminology=true"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, measure_id:)
@@ -430,7 +430,7 @@ RSpec.describe MeasureRepositoryServiceTestKit::MeasurePackage do
                                 entry: [{ resource: measure }, { resource: library }, { resource: dep_valueset }])
       stub_request(
         :post,
-        "#{url}/Measure/#{measure_id}/$package?include-terminology=true"
+        "#{url}/Measure/#{measure_id}/$cqfm.package?include-terminology=true"
       ).to_return(status: 200, body: bundle.to_json)
 
       result = run(test, url:, measure_id:)


### PR DESCRIPTION
# Summary
The [published version of the measure repository service](http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/cqfm-package) now specifies `$cqfm.package` as the endpoint for the package operation. This PR changes instances of `$package` with `$cqfm.package`.

## New behavior
No new features. Changes the package endpoint, so servers supporting `$cqfm.package` should now pass package-related tests. Servers that use `$package` should now fail on package-related tests.

## Code changes
Changed instances of `$package` to `$cqfm.package` in several files under the `lib` and `spec` directories.

# Testing guidance
* Run `rspec` to run the rspec tests
* Check that all instances of `$package` have been changed over
* Follow the setup instructions in the README to start the test kit. Then run against the locally running measure repository service on the `cqfm-package` branch. Check that the package-related tests pass. If using the measure repository setup docs for example input values, you may run into some failing tests related to the `identifier` field. This is unrelated to the package functionality.
[MeasureRepoServiceAndTestKitSetup.pdf](https://github.com/projecttacoma/measure-repository-service-test-kit/files/13268164/MeasureRepoServiceAndTestKitSetup.pdf)
